### PR TITLE
[PREVIEW] SSCS-3788 Send different notifications for follow up rounds of questions

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -8,6 +8,8 @@
     <gav regex="true">^org\.springframework:spring-.*:.*$</gav>
     <cve>CVE-2018-1257</cve>
     <cve>CVE-2018-1258</cve>
+    <cve>CVE-2018-11039</cve>
+    <cve>CVE-2018-11040</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -6,6 +6,7 @@ sscs_manage_emails_link = "https://track-appeal.nonprod.platform.hmcts.net/manag
 sscs_track_your_appeal_link = "https://track-appeal.nonprod.platform.hmcts.net/trackyourappeal/appeal_id"
 hearing_info_link = "https://track-appeal.nonprod.platform.hmcts.net/abouthearing/appeal_id"
 claiming_expenses_link = "https://track-appeal.nonprod.platform.hmcts.net/expenses/appeal_id"
+online_hearing_link = "https://sscs-cor-frontend-aat.service.core-compute-aat.internal/login"
 
 idam_redirect_url = "https://evidence-sharing-preprod.sscs.reform.hmcts.net"
 notification_key = "notification-key"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -105,6 +105,7 @@ module "track-your-appeal-notifications" {
     CLAIMING_EXPENSES_LINK        = "${var.claiming_expenses_link}"
     JOB_SCHEDULER_POLL_INTERVAL   = "${var.job_scheduler_poll_interval}"
     EMAIL_MAC_SECRET_TEXT         = "${data.vault_generic_secret.mac_secret.data["value"]}"
+    ONLINE_HEARING_LINK           = "${var.online_hearing_link}"
 
     // db vars
     JOB_SCHEDULER_DB_HOST               = "${module.db-notif.host_name}"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -72,6 +72,11 @@ variable "claiming_expenses_link" {
   default = "http://localhost:3000/expenses/appeal_id"
 }
 
+variable "online_hearing_link" {
+  type    = "string"
+  default = "http://localhost:8090/login"
+}
+
 variable "job_scheduler_poll_interval" {
   type    = "string"
   default = "30000"

--- a/src/main/java/uk/gov/hmcts/sscs/config/AppConstants.java
+++ b/src/main/java/uk/gov/hmcts/sscs/config/AppConstants.java
@@ -32,6 +32,7 @@ public final class AppConstants {
     public static final String MANAGE_EMAILS_LINK_LITERAL = "manage_emails_link";
     public static final int MAX_DWP_RESPONSE_DAYS = 35;
     public static final String MRN_DETAILS_LITERAL = "mrn_details";
+    public static final String ONLINE_HEARING_LINK_LITERAL = "online_hearing_link";
     public static final String PHONE_NUMBER = "phone_number";
     public static final String POSTCODE_LITERAL = "postcode";
     public static final String REASONS_FOR_APPEALING_DETAILS_LITERAL = "reasons_for_appealing_details";

--- a/src/main/java/uk/gov/hmcts/sscs/config/NotificationConfig.java
+++ b/src/main/java/uk/gov/hmcts/sscs/config/NotificationConfig.java
@@ -23,6 +23,8 @@ public class NotificationConfig {
     private String claimingExpensesLink;
     @Value("${hearing.info.link}")
     private String hearingInfoLink;
+    @Value("${online.hearing.link}")
+    private String onlineHearingLink;
 
     @Autowired
     private Environment env;
@@ -51,10 +53,13 @@ public class NotificationConfig {
         return Link.builder().linkUrl(hearingInfoLink).build();
     }
 
+    public Link getOnlineHearingLink() {
+        return Link.builder().linkUrl(onlineHearingLink).build();
+    }
+
     public Template getTemplate(String emailTemplateName, String smsTemplateName, Benefit benefit) {
         return Template.builder().emailTemplateId(env.getProperty("notification." + emailTemplateName + ".emailId"))
                 .smsTemplateId(env.getProperty("notification." + smsTemplateName + ".smsId"))
                 .smsSenderTemplateId(env.getProperty("smsSender." + benefit.toString().toLowerCase())).build();
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/sscs/domain/notify/EventType.java
+++ b/src/main/java/uk/gov/hmcts/sscs/domain/notify/EventType.java
@@ -24,7 +24,8 @@ public enum EventType {
     DWP_RESPONSE_LATE_REMINDER("dwpResponseLateReminder"),
     DO_NOT_SEND(""),
 
-    QUESTION_ROUND_ISSUED("question_round_issued");
+    QUESTION_ROUND_ISSUED("question_round_issued"),
+    QUESTION_DEADLINE_ELAPSED("question_deadline_elapsed");
 
     private String id;
 

--- a/src/main/java/uk/gov/hmcts/sscs/factory/NotificationFactory.java
+++ b/src/main/java/uk/gov/hmcts/sscs/factory/NotificationFactory.java
@@ -35,7 +35,7 @@ public class NotificationFactory {
         }
 
         Benefit benefit = getBenefitByCode(notificationWrapper.getCcdResponseWrapper().getNewCcdResponse().getAppeal().getBenefitType().getCode());
-        Template template = personalisation.getTemplate(notificationWrapper.getNotificationType(), benefit);
+        Template template = personalisation.getTemplate(notificationWrapper, benefit);
 
         CcdResponse ccdResponse = notificationWrapper.getCcdResponseWrapper().getNewCcdResponse();
         Destination destination = ccdResponse.getSubscriptions().getAppellantSubscription().getDestination();

--- a/src/main/java/uk/gov/hmcts/sscs/personalisation/CohPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/sscs/personalisation/CohPersonalisation.java
@@ -3,7 +3,10 @@ package uk.gov.hmcts.sscs.personalisation;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.sscs.domain.Benefit;
+import uk.gov.hmcts.sscs.domain.notify.Template;
 import uk.gov.hmcts.sscs.factory.CohNotificationWrapper;
+import uk.gov.hmcts.sscs.service.coh.QuestionRounds;
 import uk.gov.hmcts.sscs.service.coh.QuestionService;
 
 @Component
@@ -21,5 +24,14 @@ public class CohPersonalisation extends Personalisation<CohNotificationWrapper> 
         placeholders.put("questions_end_date", questionRequiredByDate);
 
         return placeholders;
+    }
+
+    public Template getTemplate(CohNotificationWrapper notificationWrapper, Benefit benefit) {
+        // If we remembered the question rounds before we would not need to make this call but currently Personalisation is a singleton
+        QuestionRounds questionRounds = questionService.getQuestionRounds(notificationWrapper.getIdamTokens(), notificationWrapper.getOnlineHearingId());
+        if (questionRounds.getCurrentQuestionRound() == 1) {
+            return super.getTemplate(notificationWrapper, benefit);
+        }
+        return config.getTemplate("follow_up_question_round_issued", "follow_up_question_round_issued", benefit);
     }
 }

--- a/src/main/java/uk/gov/hmcts/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/sscs/personalisation/Personalisation.java
@@ -37,7 +37,7 @@ public class Personalisation<E extends NotificationWrapper> {
     private static final org.slf4j.Logger LOG = getLogger(Personalisation.class);
 
     @Autowired
-    private NotificationConfig config;
+    protected NotificationConfig config;
 
     @Autowired
     private HearingContactDateExtractor hearingContactDateExtractor;
@@ -190,7 +190,8 @@ public class Personalisation<E extends NotificationWrapper> {
         return date.format(DateTimeFormatter.ofPattern(HEARING_TIME_FORMAT));
     }
 
-    public Template getTemplate(EventType type, Benefit benefit) {
+    public Template getTemplate(E notificationWrapper, Benefit benefit) {
+        EventType type = notificationWrapper.getNotificationType();
         String smsTemplateId = isSendSmsSubscriptionConfirmation() ? SUBSCRIPTION_CREATED.getId() : type.getId();
         return config.getTemplate(type.getId(), smsTemplateId, benefit);
     }

--- a/src/main/java/uk/gov/hmcts/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/sscs/personalisation/Personalisation.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.sscs.config.NotificationConfig;
 import uk.gov.hmcts.sscs.domain.*;
+import uk.gov.hmcts.sscs.domain.notify.Destination;
 import uk.gov.hmcts.sscs.domain.notify.Event;
 import uk.gov.hmcts.sscs.domain.notify.EventType;
 import uk.gov.hmcts.sscs.domain.notify.Template;
@@ -76,6 +77,11 @@ public class Personalisation<E extends NotificationWrapper> {
             personalisation.put(CLAIMING_EXPENSES_LINK_LITERAL, config.getClaimingExpensesLink().replace(APPEAL_ID, appellantSubscription.getTya()));
             personalisation.put(HEARING_INFO_LINK_LITERAL,
                     config.getHearingInfoLink().replace(APPEAL_ID_LITERAL, appellantSubscription.getTya()));
+        }
+        Destination destination = appellantSubscription.getDestination();
+        if (destination != null && destination.email != null) {
+            String email = destination.email;
+            personalisation.put(ONLINE_HEARING_LINK_LITERAL, config.getOnlineHearingLink().replace("{email}", email));
         }
 
         personalisation.put(FIRST_TIER_AGENCY_ACRONYM, DWP_ACRONYM);

--- a/src/main/java/uk/gov/hmcts/sscs/service/coh/QuestionService.java
+++ b/src/main/java/uk/gov/hmcts/sscs/service/coh/QuestionService.java
@@ -32,4 +32,12 @@ public class QuestionService {
             );
         }
     }
+
+    public QuestionRounds getQuestionRounds(IdamTokens idamTokens, String onlineHearingId) {
+        return cohClient.getQuestionRounds(
+                    idamTokens.getIdamOauth2Token(),
+                    idamTokens.getServiceAuthorization(),
+                    onlineHearingId
+            );
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -80,6 +80,7 @@ manage.emails.link: ${SSCS_MANAGE_EMAILS_LINK:http://localhost:3000/manage-email
 track.appeal.link: ${SSCS_TRACK_YOUR_APPEAL_LINK:http://localhost:3000/trackyourappeal/appeal_id}
 hearing.info.link: ${HEARING_INFO_LINK:http://localhost:3000/abouthearing/appeal_id}
 claiming.expenses.link: ${CLAIMING_EXPENSES_LINK:http://localhost:3000/expenses/appeal_id}
+online.hearing.link: ${ONLINE_HEARING_LINK:http://localhost:8090/login}?email={email}
 
 job.scheduler:
   retryPolicy:
@@ -134,6 +135,9 @@ notification:
   question_round_issued:
     emailId: ccfbfcac-847d-4e55-955c-096802c131a0
     smsId: f4138438-9707-4d52-9f54-dfa68e96856f
+  question_deadline_elapsed:
+    emailId: 48f2b7d1-cb71-4f60-b145-dfcf63cc4fcd
+    smsId: 181fb0f5-0cc8-4d57-903f-9e5db2a76b88
 
 smsSender:
   pip: 80b11be7-5c10-2773-8351-070e22d5ab6b

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -135,6 +135,9 @@ notification:
   question_round_issued:
     emailId: ccfbfcac-847d-4e55-955c-096802c131a0
     smsId: f4138438-9707-4d52-9f54-dfa68e96856f
+  follow_up_question_round_issued:
+    emailId: 71efa426-bfa9-473e-b3cf-da5d99e39461
+    smsId: 217b826c-e569-4fda-b0df-45736a887af8
   question_deadline_elapsed:
     emailId: 48f2b7d1-cb71-4f60-b145-dfcf63cc4fcd
     smsId: 181fb0f5-0cc8-4d57-903f-9e5db2a76b88

--- a/src/test/java/uk/gov/hmcts/sscs/factory/NotificationFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/factory/NotificationFactoryTest.java
@@ -88,6 +88,7 @@ public class NotificationFactoryTest {
         when(config.getManageEmailsLink()).thenReturn(Link.builder().linkUrl("http://link.com/manage-email-notifications/mac").build());
         when(config.getClaimingExpensesLink()).thenReturn(Link.builder().linkUrl("http://link.com/progress/appeal_id/expenses").build());
         when(config.getHearingInfoLink()).thenReturn(Link.builder().linkUrl("http://link.com/progress/appeal_id/abouthearing").build());
+        when(config.getOnlineHearingLink()).thenReturn(Link.builder().linkUrl("http://link.com/onlineHearing?email={email}").build());
         when(macService.generateToken("ABC", PIP.name())).thenReturn("ZYX");
 
         RegionalProcessingCenter rpc = new RegionalProcessingCenter();

--- a/src/test/java/uk/gov/hmcts/sscs/personalisation/CohPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/personalisation/CohPersonalisationTest.java
@@ -1,7 +1,9 @@
 package uk.gov.hmcts.sscs.personalisation;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static uk.gov.hmcts.sscs.domain.Benefit.PIP;
@@ -18,11 +20,14 @@ import uk.gov.hmcts.sscs.config.NotificationConfig;
 import uk.gov.hmcts.sscs.domain.*;
 import uk.gov.hmcts.sscs.domain.idam.IdamTokens;
 import uk.gov.hmcts.sscs.domain.notify.Event;
+import uk.gov.hmcts.sscs.domain.notify.EventType;
 import uk.gov.hmcts.sscs.domain.notify.Link;
+import uk.gov.hmcts.sscs.domain.notify.Template;
 import uk.gov.hmcts.sscs.extractor.HearingContactDateExtractor;
 import uk.gov.hmcts.sscs.factory.CohNotificationWrapper;
 import uk.gov.hmcts.sscs.service.MessageAuthenticationServiceImpl;
 import uk.gov.hmcts.sscs.service.RegionalProcessingCenterService;
+import uk.gov.hmcts.sscs.service.coh.QuestionRounds;
 import uk.gov.hmcts.sscs.service.coh.QuestionService;
 
 public class CohPersonalisationTest {
@@ -103,5 +108,40 @@ public class CohPersonalisationTest {
         Map<String, String> placeholders = cohPersonalisation.create(new CohNotificationWrapper(idamTokens, someHearingId, ccdResponseWrapper));
 
         assertThat(placeholders, hasEntry("questions_end_date", expectedRequiredByDate));
+    }
+
+    @Test
+    public void setsCorrectTemplatesForFirstQuestionRound() {
+        String someHearingId = "someHearingId";
+        IdamTokens idamTokens = IdamTokens.builder().build();
+        QuestionRounds questionRounds = mock(QuestionRounds.class);
+        when(questionService.getQuestionRounds(idamTokens, someHearingId)).thenReturn(questionRounds);
+        when(questionRounds.getCurrentQuestionRound()).thenReturn(1);
+        CohNotificationWrapper cohNotificationWrapper = new CohNotificationWrapper(
+                idamTokens,
+                someHearingId,
+                CcdResponseWrapper.builder().newCcdResponse(
+                        CcdResponse.builder().notificationType(EventType.QUESTION_ROUND_ISSUED).build()
+                ).build());
+        Template expectedTemplate = Template.builder().build();
+        when(config.getTemplate(EventType.QUESTION_ROUND_ISSUED.getId(), EventType.QUESTION_ROUND_ISSUED.getId(), Benefit.PIP)).thenReturn(expectedTemplate);
+
+        Template template = cohPersonalisation.getTemplate(cohNotificationWrapper, Benefit.PIP);
+        assertThat(template, is(expectedTemplate));
+    }
+
+    @Test
+    public void setsCorrectTemplatesForSecondQuestionRound() {
+        String someHearingId = "someHearingId";
+        IdamTokens idamTokens = IdamTokens.builder().build();
+        QuestionRounds questionRounds = mock(QuestionRounds.class);
+        when(questionService.getQuestionRounds(idamTokens, someHearingId)).thenReturn(questionRounds);
+        when(questionRounds.getCurrentQuestionRound()).thenReturn(2);
+        CohNotificationWrapper cohNotificationWrapper = new CohNotificationWrapper(idamTokens, someHearingId, CcdResponseWrapper.builder().build());
+        Template expectedTemplate = Template.builder().build();
+        when(config.getTemplate("follow_up_question_round_issued", "follow_up_question_round_issued", Benefit.PIP)).thenReturn(expectedTemplate);
+
+        Template template = cohPersonalisation.getTemplate(cohNotificationWrapper, Benefit.PIP);
+        assertThat(template, is(expectedTemplate));
     }
 }

--- a/src/test/java/uk/gov/hmcts/sscs/personalisation/CohPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/personalisation/CohPersonalisationTest.java
@@ -57,6 +57,7 @@ public class CohPersonalisationTest {
         when(config.getManageEmailsLink()).thenReturn(Link.builder().linkUrl("http://link.com/manage-email-notifications/mac").build());
         when(config.getClaimingExpensesLink()).thenReturn(Link.builder().linkUrl("http://link.com/progress/appeal_id/expenses").build());
         when(config.getHearingInfoLink()).thenReturn(Link.builder().linkUrl("http://link.com/progress/appeal_id/abouthearing").build());
+        when(config.getOnlineHearingLink()).thenReturn(Link.builder().linkUrl("http://link.com/onlineHearing?email={email}").build());
         when(macService.generateToken("GLSCRR", PIP.name())).thenReturn("ZYX");
 
         RegionalProcessingCenter rpc = new RegionalProcessingCenter();

--- a/src/test/java/uk/gov/hmcts/sscs/personalisation/SubscriptionPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/personalisation/SubscriptionPersonalisationTest.java
@@ -65,6 +65,7 @@ public class SubscriptionPersonalisationTest {
         when(config.getManageEmailsLink()).thenReturn(Link.builder().linkUrl("http://link.com/manage-email-notifications/mac").build());
         when(config.getClaimingExpensesLink()).thenReturn(Link.builder().linkUrl("http://link.com/progress/appeal_id/expenses").build());
         when(config.getHearingInfoLink()).thenReturn(Link.builder().linkUrl("http://link.com/progress/appeal_id/abouthearing").build());
+        when(config.getOnlineHearingLink()).thenReturn(Link.builder().linkUrl("http://link.com/onlineHearing?email={email}").build());
         when(macService.generateToken("GLSCRR", PIP.name())).thenReturn("ZYX");
         when(hearingContactDateExtractor.extract(any())).thenReturn(Optional.empty());
 

--- a/src/test/java/uk/gov/hmcts/sscs/service/coh/QuestionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/service/coh/QuestionServiceTest.java
@@ -62,4 +62,15 @@ public class QuestionServiceTest {
 
         new QuestionService(cohClient).getQuestionRequiredByDate(idamTokens, someHearingId);
     }
+
+    @Test
+    public void getsQuestionRounds() {
+        QuestionRounds expectedQuestionRounds = new QuestionRounds(1, singletonList(new QuestionRound(emptyList())));
+        when(cohClient.getQuestionRounds(authHeader, serviceAuthHeader, someHearingId))
+                .thenReturn(expectedQuestionRounds);
+
+        QuestionRounds questionRounds = new QuestionService(cohClient).getQuestionRounds(idamTokens, someHearingId);
+
+        assertThat(questionRounds, is(expectedQuestionRounds));
+    }
 }


### PR DESCRIPTION
If the online panel issue more questions after the first round we do not
want the notifications to be the same. Changed the logic to select a
template based on the notification event and the current question round.