### PR TITLE
[PREVIEW] SSCS-3788 Send different notifications for follow up rounds of questions

### DIFF
--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/CohNotificationsIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/CohNotificationsIt.java
@@ -105,7 +105,7 @@ public class CohNotificationsIt {
                 .thenReturn(caseDetails);
         when(cohClient.getQuestionRounds(any(), any(), any())).thenReturn(
                 new QuestionRounds(1, singletonList(
-                        new QuestionRound(Collections.singletonList(new QuestionReferences("expiryDate")))
+                        new QuestionRound(Collections.singletonList(new QuestionReferences("2018-08-11T23:59:59Z")))
                 ))
         );
 
@@ -125,7 +125,7 @@ public class CohNotificationsIt {
 
         assertHttpStatus(response, HttpStatus.OK);
         verify(client, times(1)).sendEmail(eq(emailTemplateId), eq("joe@bloggs.com"),
-                argThat(argument -> "expiryDate".equals(argument.get("questions_end_date"))),
+                argThat(argument -> "11 August 2018".equals(argument.get("questions_end_date"))),
                 any()
         );
         verify(client, times(1)).sendSms(any(), any(), any(), any(), any());

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/AbstractFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/AbstractFunctionalTest.java
@@ -70,7 +70,7 @@ public abstract class AbstractFunctionalTest {
     protected SscsCaseData caseData;
 
     @Autowired
-    private CcdClient ccdClient;
+    protected CcdClient ccdClient;
 
     @Before
     public void setup() {
@@ -84,12 +84,16 @@ public abstract class AbstractFunctionalTest {
 
         caseReference = generateRandomCaseReference();
 
-        caseData = buildSscsCaseData(caseReference, "Yes", "Yes", SYA_APPEAL_CREATED);
+        caseData = createCaseData();
 
         SscsCaseDetails caseDetails = ccdClient.createCase(caseData, "Create case");
 
         assertNotNull(caseDetails);
         caseId = caseDetails.getId();
+    }
+
+    protected SscsCaseData createCaseData() {
+        return buildSscsCaseData(caseReference, "Yes", "Yes", SYA_APPEAL_CREATED);
     }
 
     protected static String generateRandomCaseReference() {

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/CohNotificationFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/CohNotificationFunctionalTest.java
@@ -1,103 +1,152 @@
-//package uk.gov.hmcts.reform.sscs.functional;
-//
-//import static uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType.QUESTION_ROUND_ISSUED_NOTIFICATION;
-//
-//import io.restassured.RestAssured;
-//import io.restassured.http.ContentType;
-//import io.restassured.response.Response;
-//import io.restassured.response.ValidatableResponse;
-//import io.restassured.specification.RequestSpecification;
-//import java.io.IOException;
-//import java.util.List;
-//import org.junit.Ignore;
-//import org.springframework.beans.factory.annotation.Value;
-//import org.springframework.http.HttpHeaders;
-//import org.springframework.http.HttpStatus;
-//import uk.gov.service.notify.Notification;
-//import uk.gov.service.notify.NotificationClientException;
-//
-//public class CohNotificationFunctionalTest extends AbstractFunctionalTest {
-//    private static final  String COH_URL = "http://coh-cor-aat.service.core-compute-aat.internal";
-//
-//    @Value("${notification.question_round_issued.emailId}")
-//    private String questionRoundIssuedEmailTemplateId;
-//
-//    @Value("${notification.question_round_issued.smsId}")
-//    private String questionRoundIssuedSmsTemplateId;
-//
-//
-//    //TODO: Temp ignore, fixed as part of Chris's PR
-//    @Ignore
-//    public void shouldSendQuestionsReadyNotifications() throws IOException, InterruptedException, NotificationClientException {
-//        String hearingId = createHearingWithQuestions(caseId);
-//        simulateCohCallback(QUESTION_ROUND_ISSUED_NOTIFICATION, hearingId);
-//
-//        List<Notification> notifications = tryFetchNotificationsForTestCase(questionRoundIssuedEmailTemplateId, questionRoundIssuedSmsTemplateId);
-//
-//        assertNotificationBodyContains(notifications, questionRoundIssuedEmailTemplateId, caseData.getCaseReference());
-//    }
-//
-//    private String createHearingWithQuestions(Long caseId) throws InterruptedException {
-//        String hearingId = createHearing(caseId);
-//        createQuestion(hearingId);
-//        issueQuestions(hearingId);
-//
-//        return hearingId;
-//    }
-//
-//    private String createHearing(Long caseId) {
-//        String createHearingJson = "{\n"
-//                + "  \"case_id\": \"" + caseId + "\",\n"
-//                + "  \"jurisdiction\": \"SSCS\",\n"
-//                + "  \"start_date\": \"2018-08-17T15:20:37.746Z\",\n"
-//                + "  \"state\": \"string\"\n"
-//                + "}";
-//
-//        RestAssured.useRelaxedHTTPSValidation();
-//        Response createHearingResponse = makeRequest(createHearingJson)
-//                .post(COH_URL + "/continuous-online-hearings");
-//        return checkResponseCreated(createHearingResponse)
-//                .contentType(ContentType.JSON)
-//                .extract().response()
-//                .jsonPath().getString("online_hearing_id");
-//    }
-//
-//    private void createQuestion(String hearingId) {
-//        String createQuestionJson = "{\n"
-//                + "  \"owner_reference\": \"string\",\n"
-//                + "  \"question_body_text\": \"string\",\n"
-//                + "  \"question_header_text\": \"string\",\n"
-//                + "  \"question_ordinal\": \"1\",\n"
-//                + "  \"question_round\": \"1\"\n"
-//                + "}";
-//        Response createQuestionResponse = makeRequest(createQuestionJson)
-//                .post(COH_URL + "/continuous-online-hearings/" + hearingId + "/questions");
-//        checkResponseCreated(createQuestionResponse);
-//    }
-//
-//    private void issueQuestions(String hearingId) throws InterruptedException {
-//        makeRequest("{\"state_name\": \"question_issue_pending\"}")
-//                .put(COH_URL + "/continuous-online-hearings/" + hearingId + "/questionrounds/1")
-//                .then()
-//                .statusCode(HttpStatus.OK.value());
-//
-//        // Need to wait 60 seconds for the question round to be issued, need to find a better way to do this.
-//        Thread.sleep(60000);
-//    }
-//
-//    private ValidatableResponse checkResponseCreated(Response request) {
-//        return request
-//                .then()
-//                .statusCode(HttpStatus.CREATED.value());
-//    }
-//
-//    private RequestSpecification makeRequest(String createQuestionJson) {
-//        return RestAssured
-//                .given()
-//                .header(HttpHeaders.AUTHORIZATION, "someValue")
-//                .header("ServiceAuthorization", "someValue")
-//                .contentType("application/json")
-//                .body(createQuestionJson)
-//                .when();
-//    }
-//}
+package uk.gov.hmcts.reform.sscs.functional;
+
+import static uk.gov.hmcts.reform.sscs.SscsCaseDataUtils.builderSscsCaseData;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.SYA_APPEAL_CREATED;
+import static uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType.QUESTION_ROUND_ISSUED_NOTIFICATION;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Supplier;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import uk.gov.hmcts.reform.sscs.ccd.domain.OnlinePanel;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.service.notify.Notification;
+import uk.gov.service.notify.NotificationClientException;
+
+public class CohNotificationFunctionalTest extends AbstractFunctionalTest {
+    private static final String COH_URL = "http://coh-cor-aat.service.core-compute-aat.internal";
+
+    @Value("${notification.question_round_issued.emailId}")
+    private String questionRoundIssuedEmailTemplateId;
+
+    @Value("${notification.question_round_issued.smsId}")
+    private String questionRoundIssuedSmsTemplateId;
+
+    @Override
+    protected SscsCaseData createCaseData() {
+        SscsCaseData.SscsCaseDataBuilder sscsCaseDataBuilder = builderSscsCaseData(caseReference, "Yes", "Yes", SYA_APPEAL_CREATED);
+        return sscsCaseDataBuilder.onlinePanel(
+                OnlinePanel.builder()
+                        .assignedTo("Judge")
+                        .medicalMember("medic")
+                        .disabilityQualifiedMember("disQualMemeber")
+                        .build())
+                .build();
+    }
+
+    @Test
+    public void shouldSendQuestionsReadyNotifications() throws IOException, InterruptedException, NotificationClientException {
+        String hearingId = createHearingWithQuestions(caseId);
+        simulateCohCallback(QUESTION_ROUND_ISSUED_NOTIFICATION, hearingId);
+
+        List<Notification> notifications = tryFetchNotificationsForTestCase(questionRoundIssuedEmailTemplateId, questionRoundIssuedSmsTemplateId);
+
+        assertNotificationBodyContains(notifications, questionRoundIssuedEmailTemplateId, caseData.getCaseReference());
+    }
+
+    private String createHearingWithQuestions(Long caseId) throws InterruptedException {
+        String hearingId = createHearing(caseId);
+        System.out.println("Created online hearing [" + hearingId + "] case id [" + caseId + "]");
+        createQuestion(hearingId);
+        issueQuestions(hearingId);
+
+        return hearingId;
+    }
+
+    private String createHearing(Long caseId) {
+        String createHearingJson = "{\n"
+                + "  \"case_id\": \"" + caseId + "\",\n"
+                + "  \"jurisdiction\": \"SSCS\",\n"
+                + "  \"start_date\": \"2018-08-17T15:20:37.746Z\",\n"
+                + "  \"state\": \"string\"\n"
+                + "}";
+
+        RestAssured.useRelaxedHTTPSValidation();
+        Response createHearingResponse = makeRequest(createHearingJson)
+                .post(COH_URL + "/continuous-online-hearings");
+        return checkResponseCreated(createHearingResponse)
+                .contentType(ContentType.JSON)
+                .extract().response()
+                .jsonPath().getString("online_hearing_id");
+    }
+
+    private void createQuestion(String hearingId) {
+        String createQuestionJson = "{\n"
+                + "  \"owner_reference\": \"string\",\n"
+                + "  \"question_body_text\": \"string\",\n"
+                + "  \"question_header_text\": \"string\",\n"
+                + "  \"question_ordinal\": \"1\",\n"
+                + "  \"question_round\": \"1\"\n"
+                + "}";
+        Response createQuestionResponse = makeRequest(createQuestionJson)
+                .post(COH_URL + "/continuous-online-hearings/" + hearingId + "/questions");
+        checkResponseCreated(createQuestionResponse);
+    }
+
+    private void issueQuestions(String hearingId) throws InterruptedException {
+        makeRequest("{\"state_name\": \"question_issue_pending\"}")
+                .put(COH_URL + "/continuous-online-hearings/" + hearingId + "/questionrounds/1")
+                .then()
+                .statusCode(HttpStatus.OK.value());
+
+        waitUntil(roundIssued(hearingId), 20L);
+    }
+
+    private ValidatableResponse checkResponseCreated(Response request) {
+        return request
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
+    private RequestSpecification makeRequest(String createQuestionJson) {
+        return RestAssured
+                .given()
+                .header(HttpHeaders.AUTHORIZATION, "someValue")
+                .header("ServiceAuthorization", "someValue")
+                .contentType("application/json")
+                .body(createQuestionJson)
+                .when();
+    }
+
+    private Supplier<Boolean> roundIssued(String hearingId) {
+        return () -> {
+            System.out.println("Checking to see if hearing [" + hearingId + "] has been issued");
+            Response response = RestAssured
+                    .given()
+                    .header(HttpHeaders.AUTHORIZATION, "someValue")
+                    .header("ServiceAuthorization", "someValue")
+                    .when()
+                    .get(COH_URL + "/continuous-online-hearings/" + hearingId + "/questionrounds/1");
+            String roundState = response.then()
+                    .statusCode(HttpStatus.OK.value())
+                    .contentType(ContentType.JSON)
+                    .extract()
+                    .response()
+                    .jsonPath().getString("question_round_state.state_name");
+            System.out.println("Current round state [" + roundState + "]");
+            return "question_issued".equals(roundState);
+        };
+    }
+
+    private static void waitUntil(Supplier<Boolean> condition, long timeoutInSeconds) throws InterruptedException {
+        long timeout = timeoutInSeconds * 1000L * 1000000L;
+        long startTime = System.nanoTime();
+        while (true) {
+            if (condition.get()) {
+                System.out.println("Found after [" + ((System.nanoTime() - startTime) / (1000L * 1000000L)) + "] seconds");
+                break;
+            } else if (System.nanoTime() - startTime >= timeout) {
+                throw new RuntimeException("Question round has not been issues in 10 seconds.");
+            }
+            Thread.sleep(100L);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/factory/NotificationFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/factory/NotificationFactory.java
@@ -36,7 +36,7 @@ public class NotificationFactory {
         }
 
         Benefit benefit = getBenefitByCode(notificationWrapper.getSscsCaseDataWrapper().getNewSscsCaseData().getAppeal().getBenefitType().getCode());
-        Template template = personalisation.getTemplate(notificationWrapper.getNotificationType(), benefit);
+        Template template = personalisation.getTemplate(notificationWrapper, benefit);
 
         SscsCaseData ccdResponse = notificationWrapper.getSscsCaseDataWrapper().getNewSscsCaseData();
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/CohDateConverterUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/CohDateConverterUtil.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.sscs.personalisation;
+
+import static java.time.format.DateTimeFormatter.ofPattern;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CohDateConverterUtil {
+
+    public static final DateTimeFormatter COH_DATE_FORMATTER = ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    public static final DateTimeFormatter EMAIL_DATE_FORMATTER = ofPattern("d MMMM yyyy");
+
+    public String toEmailDate(String cohDate) {
+        LocalDate localDate = LocalDate.parse(cohDate, COH_DATE_FORMATTER);
+        return localDate.format(EMAIL_DATE_FORMATTER);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/CohPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/CohPersonalisation.java
@@ -3,7 +3,11 @@ package uk.gov.hmcts.reform.sscs.personalisation;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Benefit;
+import uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType;
+import uk.gov.hmcts.reform.sscs.domain.notify.Template;
 import uk.gov.hmcts.reform.sscs.factory.CohNotificationWrapper;
+import uk.gov.hmcts.reform.sscs.service.coh.QuestionRounds;
 import uk.gov.hmcts.reform.sscs.service.coh.QuestionService;
 
 @Component
@@ -12,14 +16,28 @@ public class CohPersonalisation extends Personalisation<CohNotificationWrapper> 
     @Autowired
     private QuestionService questionService;
 
+    @Autowired
+    private CohDateConverterUtil cohDateConverterUtil;
+
     @Override
     public Map<String, String> create(CohNotificationWrapper notificationWrapper) {
         Map<String, String> placeholders = super.create(notificationWrapper);
 
         String questionRequiredByDate = questionService.getQuestionRequiredByDate(notificationWrapper.getOnlineHearingId());
 
-        placeholders.put("questions_end_date", questionRequiredByDate);
+        String dateEmailFormat = cohDateConverterUtil.toEmailDate(questionRequiredByDate);
+        placeholders.put("questions_end_date", dateEmailFormat);
 
         return placeholders;
+    }
+
+    public Template getTemplate(CohNotificationWrapper notificationWrapper, Benefit benefit) {
+        // If we remembered the question rounds before we would not need to make this call but currently Personalisation is a singleton
+        QuestionRounds questionRounds = questionService.getQuestionRounds(notificationWrapper.getOnlineHearingId());
+        if (questionRounds.getCurrentQuestionRound() == 1) {
+            NotificationEventType type = notificationWrapper.getNotificationType();
+            return config.getTemplate(type.getId(), type.getId(), benefit);
+        }
+        return config.getTemplate("follow_up_question_round_issued", "follow_up_question_round_issued", benefit);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
@@ -38,7 +38,7 @@ public class Personalisation<E extends NotificationWrapper> {
     private boolean sendSmsSubscriptionConfirmation;
 
     @Autowired
-    private NotificationConfig config;
+    protected NotificationConfig config;
 
     @Autowired
     private HearingContactDateExtractor hearingContactDateExtractor;
@@ -198,7 +198,8 @@ public class Personalisation<E extends NotificationWrapper> {
         return date.format(DateTimeFormatter.ofPattern(AppConstants.HEARING_TIME_FORMAT));
     }
 
-    public Template getTemplate(NotificationEventType type, Benefit benefit) {
+    public Template getTemplate(E notificationWrapper, Benefit benefit) {
+        NotificationEventType type = notificationWrapper.getNotificationType();
         String smsTemplateId = isSendSmsSubscriptionConfirmation() ? SUBSCRIPTION_CREATED_NOTIFICATION.getId() : type.getId();
         return config.getTemplate(type.getId(), smsTemplateId, benefit);
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/NotificationService.java
@@ -39,6 +39,7 @@ public class NotificationService {
 
         LOG.info("Notification event triggered {} for case id {}", notificationEventType, caseId);
 
+
         if (appellantSubscription != null && appellantSubscription.doesCaseHaveSubscriptions()
                 && notificationValidService.isNotificationStillValidToSend(wrapper.getNewSscsCaseData().getHearings(), wrapper.getNotificationType())
                 && notificationValidService.isHearingTypeValidToSendNotification(wrapper.getNewSscsCaseData(), wrapper.getNotificationType())) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/coh/QuestionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/coh/QuestionService.java
@@ -38,4 +38,14 @@ public class QuestionService {
             );
         }
     }
+
+    public QuestionRounds getQuestionRounds(String onlineHearingId) {
+        IdamTokens idamTokens = idamService.getIdamTokens();
+
+        return cohClient.getQuestionRounds(
+                    idamTokens.getIdamOauth2Token(),
+                    idamTokens.getServiceAuthorization(),
+                    onlineHearingId
+            );
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -133,6 +133,9 @@ notification:
   question_round_issued:
     emailId: ccfbfcac-847d-4e55-955c-096802c131a0
     smsId: f4138438-9707-4d52-9f54-dfa68e96856f
+  follow_up_question_round_issued:
+    emailId: 71efa426-bfa9-473e-b3cf-da5d99e39461
+    smsId: 217b826c-e569-4fda-b0df-45736a887af8
   question_deadline_elapsed:
     emailId: 48f2b7d1-cb71-4f60-b145-dfcf63cc4fcd
     smsId: 181fb0f5-0cc8-4d57-903f-9e5db2a76b88

--- a/src/test/java/uk/gov/hmcts/reform/sscs/SscsCaseDataUtils.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/SscsCaseDataUtils.java
@@ -33,6 +33,15 @@ public final class SscsCaseDataUtils {
             String subscribeSms,
             EventType eventType
     ) {
+        return builderSscsCaseData(caseReference, subscribeEmail, subscribeSms, eventType).build();
+    }
+
+    public static SscsCaseData.SscsCaseDataBuilder builderSscsCaseData(
+            String caseReference,
+            String subscribeEmail,
+            String subscribeSms,
+            EventType eventType
+    ) {
         Name name = Name.builder()
                 .title("Mr")
                 .firstName("User")
@@ -96,8 +105,7 @@ public final class SscsCaseDataUtils {
                 .caseReference(caseReference)
                 .appeal(appeal)
                 .events(Collections.singletonList(events))
-                .subscriptions(subscriptions)
-                .build();
+                .subscriptions(subscriptions);
     }
 
     public static CcdNotificationWrapper buildBasicCcdNotificationWrapper(NotificationEventType notificationType) {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/CohDateConverterUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/CohDateConverterUtilTest.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.sscs.personalisation;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class CohDateConverterUtilTest {
+    @Test
+    public void doesNotAdd0ToStartOfDate() {
+        String emailDate = new CohDateConverterUtil().toEmailDate("2018-09-01T23:59:59Z");
+        assertThat(emailDate, is("1 September 2018"));
+    }
+
+    @Test
+    public void dateInMonthIs2Digits() {
+        String emailDate = new CohDateConverterUtil().toEmailDate("2018-09-12T23:59:59Z");
+        assertThat(emailDate, is("12 September 2018"));
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/coh/QuestionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/coh/QuestionServiceTest.java
@@ -67,4 +67,15 @@ public class QuestionServiceTest {
 
         new QuestionService(cohClient, idamService).getQuestionRequiredByDate(someHearingId);
     }
+
+    @Test
+    public void getsQuestionRounds() {
+        QuestionRounds expectedQuestionRounds = new QuestionRounds(1, singletonList(new QuestionRound(emptyList())));
+        when(cohClient.getQuestionRounds(authHeader, serviceAuthHeader, someHearingId))
+                .thenReturn(expectedQuestionRounds);
+
+        QuestionRounds questionRounds = new QuestionService(cohClient, idamService).getQuestionRounds(someHearingId);
+
+        assertThat(questionRounds, is(expectedQuestionRounds));
+    }
 }


### PR DESCRIPTION
If the online panel issue more questions after the first round we do not
want the notifications to be the same. Changed the logic to select a
template based on the notification event and the current question round.