### PR TITLE
Use app service plan

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -72,6 +72,8 @@ module "track-your-appeal-notifications" {
   subscription = "${var.subscription}"
   capacity     = "${(var.env == "preview") ? 1 : 2}"
   common_tags  = "${var.common_tags}"
+  asp_rg       = "${var.product}-${var.component}-${var.env}"
+  asp_name     = "${var.product}-${var.component}-${var.env}"
 
   app_settings = {
     INFRASTRUCTURE_ENV          = "${var.env}"


### PR DESCRIPTION
In a few words: we currently use a service plan for application. After the change, we will have a single plan per project.

While we currently have a 1:1 mapping between applications and compute resources, with a shared plan we can fit more apps into a single compute resource.
The change is rolled out in two stages.

1. Explicitly enable the app service plan in Terraform
1. Switch the service plan to use a shared service plan.

**PLEASE NOTE, THIS PR IS FOR STEP 1 ONLY**

More info on the change: https://tools.hmcts.net/confluence/display/CNP/Migrate+to+Shared+App+Service+Plan (please note that the instructions are for the full migration).