### PR TITLE
[PREVIEW] Question round deadline expiry notification

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/config/AppConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/config/AppConstants.java
@@ -35,6 +35,7 @@ public final class AppConstants {
     public static final String ONLINE_HEARING_LINK_LITERAL = "online_hearing_link";
     public static final String PHONE_NUMBER = "phone_number";
     public static final String POSTCODE_LITERAL = "postcode";
+    public static final String QUESTION_ROUND_EXPIRES_DATE_LITERAL = "question_round_expires_date";
     public static final String REASONS_FOR_APPEALING_DETAILS_LITERAL = "reasons_for_appealing_details";
     public static final String REGIONAL_OFFICE_NAME_LITERAL = "regional_office_name";
     public static final String REPRESENTATIVE_DETAILS_LITERAL = "representative_details";

--- a/src/main/java/uk/gov/hmcts/reform/sscs/domain/notify/NotificationEventType.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/domain/notify/NotificationEventType.java
@@ -25,6 +25,7 @@ public enum NotificationEventType {
     DWP_RESPONSE_LATE_REMINDER_NOTIFICATION("dwpResponseLateReminder", true, false, false),
     QUESTION_ROUND_ISSUED_NOTIFICATION("question_round_issued", false, false, true),
     QUESTION_DEADLINE_ELAPSED_NOTIFICATION("question_deadline_elapsed", false, false, true),
+    QUESTION_DEADLINE_REMINDER_NOTIFICATION("question_deadline_reminder", false, false, true),
     DO_NOT_SEND("");
 
     private String id;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
@@ -4,6 +4,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.Benefit.getBenefitByCode;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.APPEAL_RECEIVED;
 import static uk.gov.hmcts.reform.sscs.config.AppConstants.ONLINE_HEARING_LINK_LITERAL;
+import static uk.gov.hmcts.reform.sscs.config.AppConstants.QUESTION_ROUND_EXPIRES_DATE_LITERAL;
 import static uk.gov.hmcts.reform.sscs.config.AppConstants.TRIBUNAL_RESPONSE_DATE_LITERAL;
 import static uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType.*;
 
@@ -115,8 +116,9 @@ public class Personalisation<E extends NotificationWrapper> {
         setEvidenceReceivedNotificationData(personalisation, ccdResponse, notificationEventType);
         setHearingContactDate(personalisation, responseWrapper);
 
-        LocalDate sevenDaysTime = LocalDate.now().plusDays(7);
-        personalisation.put(TRIBUNAL_RESPONSE_DATE_LITERAL, notificationDateConverterUtil.toEmailDate(sevenDaysTime));
+        LocalDate today = LocalDate.now();
+        personalisation.put(TRIBUNAL_RESPONSE_DATE_LITERAL, notificationDateConverterUtil.toEmailDate(today.plusDays(7)));
+        personalisation.put(QUESTION_ROUND_EXPIRES_DATE_LITERAL, notificationDateConverterUtil.toEmailDate(today.plusDays(1)));
 
         return personalisation;
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -139,10 +139,14 @@ notification:
   question_deadline_elapsed:
     emailId: 48f2b7d1-cb71-4f60-b145-dfcf63cc4fcd
     smsId: 181fb0f5-0cc8-4d57-903f-9e5db2a76b88
+  question_deadline_reminder:
+    emailId: 29820a6a-1aa4-4518-8d08-f06f09c5d808
+    smsId: 7a14e549-9043-47fe-bae5-5f96f8e8faa5
   online:
     responseReceived:
       emailId: 90f0ed29-a616-4ce0-b4ef-108391f5d90e
       smsId: e2e166c4-3600-443d-8feb-39f2c28e8732
+
 
 smsSender:
   pip: 80b11be7-5c10-2773-8351-070e22d5ab6b

--- a/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
@@ -6,6 +6,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.Benefit.PIP;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.APPEAL_RECEIVED;
 import static uk.gov.hmcts.reform.sscs.config.AppConstants.ONLINE_HEARING_LINK_LITERAL;
+import static uk.gov.hmcts.reform.sscs.config.AppConstants.QUESTION_ROUND_EXPIRES_DATE_LITERAL;
 import static uk.gov.hmcts.reform.sscs.config.AppConstants.TRIBUNAL_RESPONSE_DATE_LITERAL;
 import static uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType.*;
 
@@ -77,7 +78,8 @@ public class PersonalisationTest {
         when(config.getClaimingExpensesLink()).thenReturn(Link.builder().linkUrl("http://link.com/progress/appeal_id/expenses").build());
         when(config.getHearingInfoLink()).thenReturn(Link.builder().linkUrl("http://link.com/progress/appeal_id/abouthearing").build());
         when(config.getOnlineHearingLink()).thenReturn(Link.builder().linkUrl("http://link.com/onlineHearing?email={email}").build());
-        when(notificationDateConverterUtil.toEmailDate(any(LocalDate.class))).thenReturn("1 January 2018");
+        when(notificationDateConverterUtil.toEmailDate(LocalDate.now().plusDays(1))).thenReturn("1 January 2018");
+        when(notificationDateConverterUtil.toEmailDate(LocalDate.now().plusDays(7))).thenReturn("1 February 2018");
         when(macService.generateToken("GLSCRR", PIP.name())).thenReturn("ZYX");
         when(hearingContactDateExtractor.extract(any())).thenReturn(Optional.empty());
 
@@ -136,7 +138,8 @@ public class PersonalisationTest {
         assertEquals(ADDRESS4, result.get(AppConstants.TOWN_LITERAL));
         assertEquals(CITY, result.get(AppConstants.COUNTY_LITERAL));
         assertEquals(POSTCODE, result.get(AppConstants.POSTCODE_LITERAL));
-        assertEquals("1 January 2018", result.get(TRIBUNAL_RESPONSE_DATE_LITERAL));
+        assertEquals("1 February 2018", result.get(TRIBUNAL_RESPONSE_DATE_LITERAL));
+        assertEquals("1 January 2018", result.get(QUESTION_ROUND_EXPIRES_DATE_LITERAL));
     }
 
     @Test


### PR DESCRIPTION
Add a notification that the appellants question need to be answered in
the next day.

This is triggered by a question_deadline_reminder notifcation from COH.