### PR TITLE
SSCS-3546 Notify appellant a hearing is required

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/domain/notify/NotificationEventType.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/domain/notify/NotificationEventType.java
@@ -26,6 +26,7 @@ public enum NotificationEventType {
     QUESTION_ROUND_ISSUED_NOTIFICATION("question_round_issued", false, false, true),
     QUESTION_DEADLINE_ELAPSED_NOTIFICATION("question_deadline_elapsed", false, false, true),
     QUESTION_DEADLINE_REMINDER_NOTIFICATION("question_deadline_reminder", false, false, true),
+    HEARING_REQUIRED_NOTIFICATION("continuous_online_hearing_relisted", false, false, true),
     DO_NOT_SEND("");
 
     private String id;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -142,11 +142,13 @@ notification:
   question_deadline_reminder:
     emailId: 29820a6a-1aa4-4518-8d08-f06f09c5d808
     smsId: 7a14e549-9043-47fe-bae5-5f96f8e8faa5
+  continuous_online_hearing_relisted:
+    emailId: 46cc347a-1a5c-40ce-993a-49769dfce626
+    smsId: 31c9b4f4-0977-4382-af94-b6ef092d59f4
   online:
     responseReceived:
       emailId: 90f0ed29-a616-4ce0-b4ef-108391f5d90e
       smsId: e2e166c4-3600-443d-8feb-39f2c28e8732
-
 
 smsSender:
   pip: 80b11be7-5c10-2773-8351-070e22d5ab6b
@@ -165,7 +167,6 @@ feign:
     config:
       core-case-data-api:
         decode404: true
-
 
 ---
 # default profile (development, production etc.)


### PR DESCRIPTION
Add a notification that the panel has decided the appellant will need to
attend a hearing.

This is triggered by a continuous_online_hearing_relisted notification
from COH.