### PR TITLE
[PREVIEW] SSCS-3900 Don't send notifications out of hours

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,7 @@ dependencyCheck {
 }
 
 repositories {
+    mavenLocal()
     maven {
         url "https://dl.bintray.com/hmcts/hmcts-maven"
     }
@@ -231,7 +232,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: versions.reformLogging
     compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
     compile group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.1.1'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-job-scheduler', version: '1.2.0'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-job-scheduler', version: '1.3.0'
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '1.0.0'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.34'
 

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -9,3 +9,6 @@ online_hearing_link = "https://sscs-cor-frontend-aat.service.core-compute-aat.in
 online_hearing_link = "https://sscs-cor-frontend-aat-staging.service.core-compute-aat.internal/login"
 
 idam_redirect_url = "https://evidence-sharing-preprod.sscs.reform.hmcts.net"
+
+hours_start_time = "0"
+hours_end_time = "23"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -132,6 +132,9 @@ module "track-your-appeal-notifications" {
     JOB_SCHEDULER_DB_NAME               = "${module.db-notif.postgresql_database}"
     JOB_SCHEDULER_DB_CONNECTION_OPTIONS = "?ssl"
     MAX_ACTIVE_DB_CONNECTIONS           = 70
+
+    HOURS_START_TIME                    = "${var.hours_start_time}"
+    HOURS_END_TIME                      = "${var.hours_end_time}"
   }
 }
 

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -11,3 +11,6 @@ root_logging_level = "DEBUG"
 log_level_spring_web = "DEBUG"
 log_level_sscs = "DEBUG"
 idam_redirect_url = "https://evidence-sharing-preprod.sscs.reform.hmcts.net"
+
+hours_start_time = "0"
+hours_end_time = "23"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -98,3 +98,13 @@ variable "database_name" {
 variable "common_tags" {
   type = "map"
 }
+
+variable "hours_start_time" {
+  type = "string"
+  default = "9"
+}
+
+variable "hours_end_time" {
+  type = "string"
+  default = "17"
+}

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/CohNotificationsIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/CohNotificationsIt.java
@@ -46,6 +46,7 @@ import uk.gov.service.notify.NotificationClient;
 @SpringBootTest
 @ActiveProfiles("integration")
 @AutoConfigureMockMvc
+// NB These could fail if it is out of hours check the config for AAT if this test has started to fail.
 public class CohNotificationsIt {
 
     MockMvc mockMvc;
@@ -73,6 +74,9 @@ public class CohNotificationsIt {
     @Mock
     NotificationBlacklist notificationBlacklist;
 
+    @MockBean
+    private OutOfHoursCalculator outOfHoursCalculator;
+
     @Autowired
     NotificationFactory factory;
 
@@ -81,6 +85,9 @@ public class CohNotificationsIt {
 
     @Autowired
     private NotificationValidService notificationValidService;
+
+    @Autowired
+    private NotificationHandler notificationHandler;
 
     @Value("${notification.question_round_issued.emailId}")
     private String emailTemplateId;
@@ -93,7 +100,7 @@ public class CohNotificationsIt {
     @Before
     public void setup() throws IOException {
         NotificationSender sender = new NotificationSender(client, null, notificationBlacklist);
-        NotificationService service = new NotificationService(sender, factory, reminderService, notificationValidService);
+        NotificationService service = new NotificationService(sender, factory, reminderService, notificationValidService, notificationHandler);
         controller = new NotificationController(service, authorisationService, ccdService, deserializer, idamService);
 
         ObjectMapper mapper = new ObjectMapper();
@@ -117,6 +124,9 @@ public class CohNotificationsIt {
                 + "   \"expiry_date\":\"2018-08-12T23:59:59Z\",\n"
                 + "   \"reason\":\"foo\"\n"
                 + "}";
+
+        outOfHoursCalculator = mock(OutOfHoursCalculator.class);
+        when(outOfHoursCalculator.isItOutOfHours()).thenReturn(false);
     }
 
     @Test

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/DwpResponseLateReminderIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/DwpResponseLateReminderIt.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.sscs.tya;
 
 import static helper.IntegrationTestHelper.assertHttpStatus;
 import static helper.IntegrationTestHelper.getRequestWithAuthHeader;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import helper.IntegrationTestHelper;
 import java.io.File;
@@ -13,6 +15,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +37,7 @@ import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.jobscheduler.services.JobExecutor;
 import uk.gov.hmcts.reform.sscs.service.AuthorisationService;
 import uk.gov.hmcts.reform.sscs.service.NotificationService;
+import uk.gov.hmcts.reform.sscs.service.OutOfHoursCalculator;
 import uk.gov.service.notify.NotificationClient;
 
 @RunWith(SpringRunner.class)
@@ -68,6 +72,9 @@ public class DwpResponseLateReminderIt {
     @Autowired
     private SscsCaseDataWrapperDeserializer deserializer;
 
+    @Mock
+    private OutOfHoursCalculator outOfHoursCalculator;
+
     @MockBean
     private IdamService idamService;
 
@@ -75,6 +82,9 @@ public class DwpResponseLateReminderIt {
     public void setup() {
         controller = new NotificationController(notificationService, authorisationService, ccdService, deserializer, idamService);
         this.mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+        outOfHoursCalculator = mock(OutOfHoursCalculator.class);
+        when(outOfHoursCalculator.isItOutOfHours()).thenReturn(false);
     }
 
     @Test

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/HearingHoldingReminderIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/HearingHoldingReminderIt.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.sscs.tya;
 
 import static helper.IntegrationTestHelper.assertHttpStatus;
 import static helper.IntegrationTestHelper.getRequestWithAuthHeader;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import helper.IntegrationTestHelper;
 import java.io.File;
@@ -35,6 +37,7 @@ import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.jobscheduler.services.JobExecutor;
 import uk.gov.hmcts.reform.sscs.service.AuthorisationService;
 import uk.gov.hmcts.reform.sscs.service.NotificationService;
+import uk.gov.hmcts.reform.sscs.service.OutOfHoursCalculator;
 import uk.gov.service.notify.NotificationClient;
 
 @RunWith(SpringRunner.class)
@@ -59,6 +62,9 @@ public class HearingHoldingReminderIt {
     @MockBean
     private JobExecutor<String> jobExecutor;
 
+    @MockBean
+    private OutOfHoursCalculator outOfHoursCalculator;
+
     @Autowired
     @Qualifier("scheduler")
     private Scheduler quartzScheduler;
@@ -76,6 +82,9 @@ public class HearingHoldingReminderIt {
     public void setup() {
         controller = new NotificationController(notificationService, authorisationService, ccdService, deserializer, idamService);
         this.mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+        outOfHoursCalculator = mock(OutOfHoursCalculator.class);
+        when(outOfHoursCalculator.isItOutOfHours()).thenReturn(false);
     }
 
     @Test

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/HearingReminderIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/HearingReminderIt.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.sscs.tya;
 
 import static helper.IntegrationTestHelper.assertHttpStatus;
 import static helper.IntegrationTestHelper.getRequestWithAuthHeader;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import helper.IntegrationTestHelper;
 import java.io.File;
@@ -32,6 +34,7 @@ import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.jobscheduler.services.JobExecutor;
 import uk.gov.hmcts.reform.sscs.service.AuthorisationService;
 import uk.gov.hmcts.reform.sscs.service.NotificationService;
+import uk.gov.hmcts.reform.sscs.service.OutOfHoursCalculator;
 import uk.gov.service.notify.NotificationClient;
 
 @RunWith(SpringRunner.class)
@@ -56,6 +59,9 @@ public class HearingReminderIt {
     @MockBean
     private JobExecutor<String> jobExecutor;
 
+    @MockBean
+    private OutOfHoursCalculator outOfHoursCalculator;
+
     @Autowired
     @Qualifier("scheduler")
     private Scheduler quartzScheduler;
@@ -73,6 +79,9 @@ public class HearingReminderIt {
     public void setup() {
         controller = new NotificationController(notificationService, authorisationService, ccdService, deserializer, idamService);
         this.mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+        outOfHoursCalculator = mock(OutOfHoursCalculator.class);
+        when(outOfHoursCalculator.isItOutOfHours()).thenReturn(false);
     }
 
     @Test

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/NotificationsIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/NotificationsIt.java
@@ -72,14 +72,23 @@ public class NotificationsIt {
 
     String json;
 
+    @Autowired
+    private NotificationHandler notificationHandler;
+
+    @MockBean
+    private OutOfHoursCalculator outOfHoursCalculator;
+
     @Before
     public void setup() throws IOException {
         NotificationSender sender = new NotificationSender(client, null, notificationBlacklist);
-        NotificationService service = new NotificationService(sender, factory, reminderService, notificationValidService);
+        NotificationService service = new NotificationService(sender, factory, reminderService, notificationValidService, notificationHandler);
         controller = new NotificationController(service, authorisationService, ccdService, deserializer, idamService);
         this.mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
         String path = getClass().getClassLoader().getResource("json/ccdResponse.json").getFile();
         json = FileUtils.readFileToString(new File(path), StandardCharsets.UTF_8.name());
+
+        outOfHoursCalculator = mock(OutOfHoursCalculator.class);
+        when(outOfHoursCalculator.isItOutOfHours()).thenReturn(false);
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/sscs/domain/notify/NotificationEventType.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/domain/notify/NotificationEventType.java
@@ -4,45 +4,47 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 
 public enum NotificationEventType {
 
-    ADJOURNED_NOTIFICATION("hearingAdjourned", true, false, false),
-    SYA_APPEAL_CREATED_NOTIFICATION("appealCreated", true, true, false),
-    APPEAL_LAPSED_NOTIFICATION("appealLapsed", true, true, false),
-    APPEAL_RECEIVED_NOTIFICATION("appealReceived", true, true, false),
-    APPEAL_WITHDRAWN_NOTIFICATION("appealWithdrawn", true, false, false),
-    APPEAL_DORMANT_NOTIFICATION("appealDormant", true, false, false),
-    DWP_RESPONSE_RECEIVED_NOTIFICATION("responseReceived", true, false, true),
-    EVIDENCE_RECEIVED_NOTIFICATION("evidenceReceived", true, false, false),
-    HEARING_BOOKED_NOTIFICATION("hearingBooked", true, false, false),
-    POSTPONEMENT_NOTIFICATION("hearingPostponed", true, false, false),
-    SUBSCRIPTION_CREATED_NOTIFICATION("subscriptionCreated", true, true, false),
-    SUBSCRIPTION_UPDATED_NOTIFICATION("subscriptionUpdated", true, true, false),
-    EVIDENCE_REMINDER_NOTIFICATION("evidenceReminder", true, false, false),
-    FIRST_HEARING_HOLDING_REMINDER_NOTIFICATION("hearingHoldingReminder", true, false, false),
-    SECOND_HEARING_HOLDING_REMINDER_NOTIFICATION("secondHearingHoldingReminder", true, false, false),
-    THIRD_HEARING_HOLDING_REMINDER_NOTIFICATION("thirdHearingHoldingReminder", true, false, false),
-    FINAL_HEARING_HOLDING_REMINDER_NOTIFICATION("finalHearingHoldingReminder", true, false, false),
-    HEARING_REMINDER_NOTIFICATION("hearingReminder", true, false, false),
-    DWP_RESPONSE_LATE_REMINDER_NOTIFICATION("dwpResponseLateReminder", true, false, false),
-    QUESTION_ROUND_ISSUED_NOTIFICATION("question_round_issued", false, false, true),
-    QUESTION_DEADLINE_ELAPSED_NOTIFICATION("question_deadline_elapsed", false, false, true),
-    QUESTION_DEADLINE_REMINDER_NOTIFICATION("question_deadline_reminder", false, false, true),
-    HEARING_REQUIRED_NOTIFICATION("continuous_online_hearing_relisted", false, false, true),
+    ADJOURNED_NOTIFICATION("hearingAdjourned", true, false, false, true),
+    SYA_APPEAL_CREATED_NOTIFICATION("appealCreated", true, true, false, true),
+    APPEAL_LAPSED_NOTIFICATION("appealLapsed", true, true, false, true),
+    APPEAL_RECEIVED_NOTIFICATION("appealReceived", true, true, false, true),
+    APPEAL_WITHDRAWN_NOTIFICATION("appealWithdrawn", true, false, false, true),
+    APPEAL_DORMANT_NOTIFICATION("appealDormant", true, false, false, true),
+    DWP_RESPONSE_RECEIVED_NOTIFICATION("responseReceived", true, false, true, true),
+    EVIDENCE_RECEIVED_NOTIFICATION("evidenceReceived", true, false, false, true),
+    HEARING_BOOKED_NOTIFICATION("hearingBooked", true, false, false, true),
+    POSTPONEMENT_NOTIFICATION("hearingPostponed", true, false, false, true),
+    SUBSCRIPTION_CREATED_NOTIFICATION("subscriptionCreated", true, true, false, true),
+    SUBSCRIPTION_UPDATED_NOTIFICATION("subscriptionUpdated", true, true, false, true),
+    EVIDENCE_REMINDER_NOTIFICATION("evidenceReminder", true, false, false, true),
+    FIRST_HEARING_HOLDING_REMINDER_NOTIFICATION("hearingHoldingReminder", true, false, false, true),
+    SECOND_HEARING_HOLDING_REMINDER_NOTIFICATION("secondHearingHoldingReminder", true, false, false, true),
+    THIRD_HEARING_HOLDING_REMINDER_NOTIFICATION("thirdHearingHoldingReminder", true, false, false, true),
+    FINAL_HEARING_HOLDING_REMINDER_NOTIFICATION("finalHearingHoldingReminder", true, false, false, true),
+    HEARING_REMINDER_NOTIFICATION("hearingReminder", true, false, false, true),
+    DWP_RESPONSE_LATE_REMINDER_NOTIFICATION("dwpResponseLateReminder", true, false, false, true),
+    QUESTION_ROUND_ISSUED_NOTIFICATION("question_round_issued", false, false, true, false),
+    QUESTION_DEADLINE_ELAPSED_NOTIFICATION("question_deadline_elapsed", false, false, true, false),
+    QUESTION_DEADLINE_REMINDER_NOTIFICATION("question_deadline_reminder", false, false, true, false),
+    HEARING_REQUIRED_NOTIFICATION("continuous_online_hearing_relisted", false, false, true, false),
     DO_NOT_SEND("");
 
     private String id;
     private boolean sendForOralCase;
     private boolean sendForPaperCase;
     private boolean sendForCohCase;
+    private boolean allowOutOfHours;
 
     NotificationEventType(String id) {
         this.id = id;
     }
 
-    NotificationEventType(String id, Boolean sendForOralCase, Boolean sendForPaperCase, Boolean sendForCohCase) {
+    NotificationEventType(String id, Boolean sendForOralCase, Boolean sendForPaperCase, Boolean sendForCohCase, Boolean allowOutOfHours) {
         this.id = id;
         this.sendForOralCase = sendForOralCase;
         this.sendForPaperCase = sendForPaperCase;
         this.sendForCohCase = sendForCohCase;
+        this.allowOutOfHours = allowOutOfHours;
     }
 
     public static NotificationEventType getNotificationById(String id) {
@@ -81,4 +83,7 @@ public enum NotificationEventType {
         return sendForCohCase;
     }
 
+    public boolean isAllowOutOfHours() {
+        return allowOutOfHours;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/factory/CcdNotificationWrapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/factory/CcdNotificationWrapper.java
@@ -6,6 +6,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.Subscription;
 import uk.gov.hmcts.reform.sscs.config.AppealHearingType;
 import uk.gov.hmcts.reform.sscs.domain.SscsCaseDataWrapper;
 import uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType;
+import uk.gov.hmcts.reform.sscs.service.scheduler.CcdActionSerializer;
 
 public class CcdNotificationWrapper implements NotificationWrapper {
     private final SscsCaseDataWrapper responseWrapper;
@@ -45,6 +46,11 @@ public class CcdNotificationWrapper implements NotificationWrapper {
         } else {
             return AppealHearingType.REGULAR;
         }
+    }
+
+    @Override
+    public String getSchedulerPayload() {
+        return new CcdActionSerializer().serialize(getCaseId());
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscs/factory/CohNotificationWrapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/factory/CohNotificationWrapper.java
@@ -1,7 +1,11 @@
 package uk.gov.hmcts.reform.sscs.factory;
 
+import static java.lang.Long.valueOf;
+
 import java.util.Objects;
 import uk.gov.hmcts.reform.sscs.domain.SscsCaseDataWrapper;
+import uk.gov.hmcts.reform.sscs.service.scheduler.CohActionSerializer;
+import uk.gov.hmcts.reform.sscs.service.scheduler.CohJobPayload;
 
 public class CohNotificationWrapper extends CcdNotificationWrapper {
     private final String onlineHearingId;
@@ -13,6 +17,11 @@ public class CohNotificationWrapper extends CcdNotificationWrapper {
 
     public String getOnlineHearingId() {
         return onlineHearingId;
+    }
+
+    @Override
+    public String getSchedulerPayload() {
+        return new CohActionSerializer().serialize(new CohJobPayload(valueOf(getCaseId()), getOnlineHearingId()));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscs/factory/NotificationWrapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/factory/NotificationWrapper.java
@@ -18,4 +18,6 @@ public interface NotificationWrapper {
     SscsCaseDataWrapper getSscsCaseDataWrapper();
 
     AppealHearingType getHearingType();
+
+    String getSchedulerPayload();
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/DateTimeProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/DateTimeProvider.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import java.time.ZonedDateTime;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DateTimeProvider {
+    public ZonedDateTime now() {
+        return ZonedDateTime.now();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/NotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/NotificationHandler.java
@@ -1,0 +1,70 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.net.UnknownHostException;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.exception.NotificationClientRuntimeException;
+import uk.gov.hmcts.reform.sscs.exception.NotificationServiceException;
+import uk.gov.hmcts.reform.sscs.factory.NotificationWrapper;
+import uk.gov.hmcts.reform.sscs.jobscheduler.model.Job;
+import uk.gov.hmcts.reform.sscs.jobscheduler.services.JobScheduler;
+import uk.gov.hmcts.reform.sscs.service.reminder.JobGroupGenerator;
+import uk.gov.service.notify.NotificationClientException;
+
+@Service
+public class NotificationHandler {
+    private static final Logger LOG = getLogger(NotificationHandler.class);
+
+    private final OutOfHoursCalculator outOfHoursCalculator;
+    private final JobScheduler jobScheduler;
+    private final JobGroupGenerator jobGroupGenerator;
+
+    @Autowired
+    public NotificationHandler(OutOfHoursCalculator outOfHoursCalculator, JobScheduler jobScheduler, JobGroupGenerator jobGroupGenerator) {
+        this.outOfHoursCalculator = outOfHoursCalculator;
+        this.jobScheduler = jobScheduler;
+        this.jobGroupGenerator = jobGroupGenerator;
+    }
+
+    public <T> void sendNotification(NotificationWrapper wrapper, String notificationTemplate, final String notificationType, SendNotification sendNotification) {
+        final String caseId = wrapper.getCaseId();
+        if (wrapper.getNotificationType().isAllowOutOfHours() || !outOfHoursCalculator.isItOutOfHours()) {
+            try {
+                LOG.info("Sending " + notificationType + " template {} for case id: {}", notificationTemplate, caseId);
+                sendNotification.send();
+                LOG.info(notificationType + " template {} sent for case id: {}", notificationTemplate, caseId);
+            } catch (Exception ex) {
+                wrapAndThrowNotificationException(caseId, notificationTemplate, ex);
+            }
+        } else {
+            String eventId = wrapper.getNotificationType().getId();
+            String jobGroup = jobGroupGenerator.generate(caseId, eventId);
+            jobScheduler.schedule(new Job<>(
+                    jobGroup,
+                    eventId,
+                    wrapper.getSchedulerPayload(),
+                    outOfHoursCalculator.getStartOfNextInHoursPeriod()
+            ));
+        }
+    }
+
+    private void wrapAndThrowNotificationException(String caseId, String templateId, Exception ex) {
+        if (ex.getCause() instanceof UnknownHostException) {
+            NotificationClientRuntimeException exception = new NotificationClientRuntimeException(ex);
+            LOG.error("Runtime error on GovUKNotify for case id: " + caseId + ", template: " + templateId, exception);
+            throw exception;
+        } else {
+            NotificationServiceException exception = new NotificationServiceException(ex);
+            LOG.error("Error on GovUKNotify for case id: " + caseId + ", template: " + templateId, exception);
+            throw exception;
+        }
+    }
+
+    @FunctionalInterface
+    public interface SendNotification {
+        void send() throws NotificationClientException;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/NotificationService.java
@@ -2,14 +2,11 @@ package uk.gov.hmcts.reform.sscs.service;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
-import java.net.UnknownHostException;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Subscription;
 import uk.gov.hmcts.reform.sscs.domain.notify.Notification;
-import uk.gov.hmcts.reform.sscs.exception.NotificationClientRuntimeException;
-import uk.gov.hmcts.reform.sscs.exception.NotificationServiceException;
 import uk.gov.hmcts.reform.sscs.factory.NotificationFactory;
 import uk.gov.hmcts.reform.sscs.factory.NotificationWrapper;
 
@@ -21,14 +18,16 @@ public class NotificationService {
     private final NotificationFactory factory;
     private final ReminderService reminderService;
     private final NotificationValidService notificationValidService;
+    private final NotificationHandler notificationHandler;
 
     @Autowired
     public NotificationService(NotificationSender notificationSender, NotificationFactory factory, ReminderService reminderService,
-                               NotificationValidService notificationValidService) {
+                               NotificationValidService notificationValidService, NotificationHandler notificationHandler) {
         this.factory = factory;
         this.notificationSender = notificationSender;
         this.reminderService = reminderService;
         this.notificationValidService = notificationValidService;
+        this.notificationHandler = notificationHandler;
     }
 
     public void createAndSendNotification(NotificationWrapper wrapper) {
@@ -47,40 +46,28 @@ public class NotificationService {
             Notification notification = factory.create(wrapper);
 
             if (appellantSubscription.isEmailSubscribed() && notification.isEmail() && notification.getEmailTemplate() != null) {
-
-                try {
-                    LOG.info("Sending email template {} for case id: {}", notification.getEmailTemplate(), caseId);
-                    notificationSender.sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference());
-                    LOG.info("Email template {} sent for case id: {}", notification.getEmailTemplate(), caseId);
-                } catch (Exception ex) {
-                    wrapAndThrowNotificationException(caseId, notification.getEmailTemplate(), ex);
-                }
+                NotificationHandler.SendNotification sendNotification = () ->
+                        notificationSender.sendEmail(
+                                notification.getEmailTemplate(),
+                                notification.getEmail(),
+                                notification.getPlaceholders(),
+                                notification.getReference()
+                        );
+                notificationHandler.sendNotification(wrapper, notification.getEmailTemplate(), "Email", sendNotification);
             }
-
             if (appellantSubscription.isSmsSubscribed() && notification.isSms() && notification.getSmsTemplate() != null) {
-
-                try {
-                    LOG.info("Sending SMS template {} for case id: {}", notification.getSmsTemplate(), caseId);
-                    notificationSender.sendSms(notification.getSmsTemplate(), notification.getMobile(), notification.getPlaceholders(), notification.getReference(), notification.getSmsSenderTemplate());
-                    LOG.info("SMS template {} sent for case id: {}", notification.getSmsTemplate(), caseId);
-                } catch (Exception ex) {
-                    wrapAndThrowNotificationException(caseId, notification.getSmsTemplate(), ex);
-                }
+                NotificationHandler.SendNotification sendNotification = () ->
+                        notificationSender.sendSms(
+                                notification.getSmsTemplate(),
+                                notification.getMobile(),
+                                notification.getPlaceholders(),
+                                notification.getReference(),
+                                notification.getSmsSenderTemplate()
+                        );
+                notificationHandler.sendNotification(wrapper, notification.getSmsTemplate(), "SMS", sendNotification);
             }
 
             reminderService.createReminders(wrapper);
-        }
-    }
-
-    private void wrapAndThrowNotificationException(String caseId, String templateId, Exception ex) {
-        if (ex.getCause() instanceof UnknownHostException) {
-            NotificationClientRuntimeException exception = new NotificationClientRuntimeException(ex);
-            LOG.error("Runtime error on GovUKNotify for case id: " + caseId + ", template: " + templateId, exception);
-            throw exception;
-        } else {
-            NotificationServiceException exception = new NotificationServiceException(ex);
-            LOG.error("Error on GovUKNotify for case id: " + caseId + ", template: " + templateId, exception);
-            throw exception;
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/OutOfHoursCalculator.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/OutOfHoursCalculator.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import java.time.ZonedDateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OutOfHoursCalculator {
+    private final DateTimeProvider dateTimeProvider;
+    private final int startTime;
+    private final int endTime;
+
+    public OutOfHoursCalculator(
+            @Autowired DateTimeProvider dateTimeProvider,
+            @Value("${outOfHours.startHour}") int startHour,
+            @Value("${outOfHours.endHour}") int endHour) {
+        this.dateTimeProvider = dateTimeProvider;
+        this.startTime = startHour;
+        this.endTime = endHour;
+    }
+
+    public boolean isItOutOfHours() {
+        ZonedDateTime now = dateTimeProvider.now();
+        int currentHour = now.getHour();
+
+        return currentHour < startTime || currentHour >= endTime;
+    }
+
+    public ZonedDateTime getStartOfNextInHoursPeriod() {
+        ZonedDateTime now = dateTimeProvider.now();
+        ZonedDateTime startDay = (now.getHour() >= startTime) ? now.plusDays(1) : now;
+
+        return startDay.withHour(startTime).withMinute(0).withSecond(0).withNano(0);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/reminder/DwpResponseLateReminder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/reminder/DwpResponseLateReminder.java
@@ -23,14 +23,14 @@ public class DwpResponseLateReminder implements ReminderHandler {
 
     private final AppealReceivedDateExtractor appealReceivedDateExtractor;
     private final JobGroupGenerator jobGroupGenerator;
-    private final JobScheduler<String> jobScheduler;
+    private final JobScheduler jobScheduler;
     private final long delay;
 
     @Autowired
     public DwpResponseLateReminder(
         AppealReceivedDateExtractor appealReceivedDateExtractor,
         JobGroupGenerator jobGroupGenerator,
-        JobScheduler<String> jobScheduler,
+        JobScheduler jobScheduler,
         @Value("${reminder.dwpResponseLateReminder.delay.seconds}") long delay
     ) {
         this.appealReceivedDateExtractor = appealReceivedDateExtractor;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/reminder/EvidenceReminder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/reminder/EvidenceReminder.java
@@ -23,14 +23,14 @@ public class EvidenceReminder implements ReminderHandler {
 
     private final DwpResponseReceivedDateExtractor dwpResponseReceivedDateExtractor;
     private final JobGroupGenerator jobGroupGenerator;
-    private final JobScheduler<String> jobScheduler;
+    private final JobScheduler jobScheduler;
     private final long evidenceReminderDelay;
 
     @Autowired
     public EvidenceReminder(
         DwpResponseReceivedDateExtractor dwpResponseReceivedDateExtractor,
         JobGroupGenerator jobGroupGenerator,
-        JobScheduler<String> jobScheduler,
+        JobScheduler jobScheduler,
         @Value("${reminder.evidenceReminder.delay.seconds}") long evidenceReminderDelay
     ) {
         this.dwpResponseReceivedDateExtractor = dwpResponseReceivedDateExtractor;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/reminder/HearingHoldingReminder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/reminder/HearingHoldingReminder.java
@@ -22,13 +22,13 @@ public class HearingHoldingReminder implements ReminderHandler {
 
     private final HearingContactDateExtractor hearingContactDateExtractor;
     private final JobGroupGenerator jobGroupGenerator;
-    private final JobScheduler<String> jobScheduler;
+    private final JobScheduler jobScheduler;
 
     @Autowired
     public HearingHoldingReminder(
         HearingContactDateExtractor hearingContactDateExtractor,
         JobGroupGenerator jobGroupGenerator,
-        JobScheduler<String> jobScheduler
+        JobScheduler jobScheduler
     ) {
         this.hearingContactDateExtractor = hearingContactDateExtractor;
         this.jobGroupGenerator = jobGroupGenerator;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/reminder/HearingReminder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/reminder/HearingReminder.java
@@ -24,7 +24,7 @@ public class HearingReminder implements ReminderHandler {
     private static final org.slf4j.Logger LOG = getLogger(HearingReminder.class);
 
     private final JobGroupGenerator jobGroupGenerator;
-    private JobScheduler<String> jobScheduler;
+    private JobScheduler jobScheduler;
 
     private long beforeFirstHearingReminder;
     private long beforeSecondHearingReminder;
@@ -32,7 +32,7 @@ public class HearingReminder implements ReminderHandler {
     @Autowired
     public HearingReminder(
         JobGroupGenerator jobGroupGenerator,
-        JobScheduler<String> jobScheduler,
+        JobScheduler jobScheduler,
         @Value("${reminder.hearingReminder.beforeFirst.seconds}") long beforeFirstHearingReminder,
         @Value("${reminder.hearingReminder.beforeSecond.seconds}") long beforeSecondHearingReminder
     ) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/scheduler/BaseActionExecutor.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/scheduler/BaseActionExecutor.java
@@ -7,33 +7,24 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.slf4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.deserialize.SscsCaseDataWrapperDeserializer;
 import uk.gov.hmcts.reform.sscs.domain.SscsCaseDataWrapper;
-import uk.gov.hmcts.reform.sscs.factory.CcdNotificationWrapper;
+import uk.gov.hmcts.reform.sscs.factory.NotificationWrapper;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
 import uk.gov.hmcts.reform.sscs.jobscheduler.services.JobExecutor;
 import uk.gov.hmcts.reform.sscs.service.NotificationService;
 
-@Component
-public class ActionExecutor implements JobExecutor<String> {
+public abstract class BaseActionExecutor<T> implements JobExecutor<T> {
+    protected static final Logger LOG = getLogger(BaseActionExecutor.class);
+    protected final NotificationService notificationService;
+    protected final CcdService ccdService;
+    protected final SscsCaseDataWrapperDeserializer deserializer;
+    protected final IdamService idamService;
 
-    private static final Logger LOG = getLogger(ActionExecutor.class);
-
-    private final NotificationService notificationService;
-    private final CcdService ccdService;
-    private final SscsCaseDataWrapperDeserializer deserializer;
-    private final IdamService idamService;
-
-    @Autowired
-    public ActionExecutor(NotificationService notificationService,
-                          CcdService ccdService,
-                          SscsCaseDataWrapperDeserializer deserializer,
-                          IdamService idamService) {
+    BaseActionExecutor(NotificationService notificationService, CcdService ccdService, SscsCaseDataWrapperDeserializer deserializer, IdamService idamService) {
         this.notificationService = notificationService;
         this.ccdService = ccdService;
         this.deserializer = deserializer;
@@ -41,25 +32,26 @@ public class ActionExecutor implements JobExecutor<String> {
     }
 
     @Override
-    public void execute(String jobId, String jobGroup, String eventId, String caseId) {
+    public void execute(String jobId, String jobGroup, String eventId, T payload) {
 
+        long caseId = getCaseId(payload);
         LOG.info("Scheduled event: {} triggered for case id: {}", eventId, caseId);
 
         IdamTokens idamTokens = idamService.getIdamTokens();
 
-        CaseDetails caseDetails = ccdService.getByCaseId(Long.valueOf(caseId), idamTokens);
+        CaseDetails caseDetails = ccdService.getByCaseId(caseId, idamTokens);
 
         if (caseDetails != null) {
             SscsCaseDataWrapper wrapper = deserializer.buildSscsCaseDataWrapper(buildCcdNode(caseDetails, eventId));
-            notificationService.createAndSendNotification(new CcdNotificationWrapper(wrapper));
-            ccdService.updateCase(null, Long.valueOf(caseId), wrapper.getNotificationEventType().getId(), "CCD Case", "Notification Service updated case", idamTokens);
+
+            notificationService.createAndSendNotification(getWrapper(wrapper, payload));
+            ccdService.updateCase(null, caseId, wrapper.getNotificationEventType().getId(), "COH Case", "Notification Service updated case", idamTokens);
         } else {
             LOG.warn("Case id: {} could not be found for event: {}", caseId, eventId);
         }
     }
 
     private ObjectNode buildCcdNode(CaseDetails caseDetails, String jobName) {
-
         ObjectMapper mapper = new ObjectMapper();
         JsonNode jsonNode = mapper.valueToTree(caseDetails);
         ObjectNode node = JsonNodeFactory.instance.objectNode();
@@ -69,4 +61,8 @@ public class ActionExecutor implements JobExecutor<String> {
 
         return node;
     }
+
+    protected abstract NotificationWrapper getWrapper(SscsCaseDataWrapper wrapper, T payload);
+
+    protected abstract long getCaseId(T payload);
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/scheduler/CcdActionDeserializer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/scheduler/CcdActionDeserializer.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.sscs.jobscheduler.services.JobPayloadDeserializer;
 
 @Component
-public class ActionDeserializer implements JobPayloadDeserializer<String> {
+public class CcdActionDeserializer implements JobPayloadDeserializer<String> {
 
     @Override
     public String deserialize(String payload) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/scheduler/CcdActionExecutor.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/scheduler/CcdActionExecutor.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.reform.sscs.service.scheduler;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
+import uk.gov.hmcts.reform.sscs.deserialize.SscsCaseDataWrapperDeserializer;
+import uk.gov.hmcts.reform.sscs.domain.SscsCaseDataWrapper;
+import uk.gov.hmcts.reform.sscs.factory.CcdNotificationWrapper;
+import uk.gov.hmcts.reform.sscs.factory.NotificationWrapper;
+import uk.gov.hmcts.reform.sscs.idam.IdamService;
+import uk.gov.hmcts.reform.sscs.service.NotificationService;
+
+public class CcdActionExecutor extends BaseActionExecutor<String> {
+
+    @Autowired
+    public CcdActionExecutor(NotificationService notificationService,
+                             CcdService ccdService,
+                             SscsCaseDataWrapperDeserializer deserializer,
+                             IdamService idamService) {
+        super(notificationService, ccdService, deserializer, idamService);
+    }
+
+    @Override
+    protected NotificationWrapper getWrapper(SscsCaseDataWrapper wrapper, String payload) {
+        return new CcdNotificationWrapper(wrapper);
+    }
+
+    @Override
+    protected long getCaseId(String payload) {
+        return Long.valueOf(payload);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/scheduler/CcdActionSerializer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/scheduler/CcdActionSerializer.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.sscs.jobscheduler.services.JobPayloadSerializer;
 
 @Component
-public class ActionSerializer implements JobPayloadSerializer<String> {
+public class CcdActionSerializer implements JobPayloadSerializer<String> {
 
     @Override
     public String serialize(String payload) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/scheduler/CohActionDeserializer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/scheduler/CohActionDeserializer.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.sscs.service.scheduler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.sscs.jobscheduler.services.JobPayloadDeserializer;
+
+@Component
+public class CohActionDeserializer implements JobPayloadDeserializer<CohJobPayload> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public CohJobPayload deserialize(String payload) {
+        try {
+            return objectMapper.readValue(payload, CohJobPayload.class);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Cannot deserialize payload as CohJobPayload [" + payload + "]", e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/scheduler/CohActionExecutor.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/scheduler/CohActionExecutor.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.sscs.service.scheduler;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
+import uk.gov.hmcts.reform.sscs.deserialize.SscsCaseDataWrapperDeserializer;
+import uk.gov.hmcts.reform.sscs.domain.SscsCaseDataWrapper;
+import uk.gov.hmcts.reform.sscs.factory.CohNotificationWrapper;
+import uk.gov.hmcts.reform.sscs.factory.NotificationWrapper;
+import uk.gov.hmcts.reform.sscs.idam.IdamService;
+import uk.gov.hmcts.reform.sscs.service.NotificationService;
+
+public class CohActionExecutor extends BaseActionExecutor<CohJobPayload> {
+
+    @Autowired
+    public CohActionExecutor(NotificationService notificationService,
+                             CcdService ccdService,
+                             SscsCaseDataWrapperDeserializer deserializer,
+                             IdamService idamService) {
+        super(notificationService, ccdService, deserializer, idamService);
+    }
+
+    @Override
+    protected NotificationWrapper getWrapper(SscsCaseDataWrapper wrapper, CohJobPayload payload) {
+        return new CohNotificationWrapper(payload.getOnlineHearingId(), wrapper);
+    }
+
+    @Override
+    protected long getCaseId(CohJobPayload payload) {
+        return payload.getCaseId();
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/scheduler/CohActionSerializer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/scheduler/CohActionSerializer.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.sscs.service.scheduler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.sscs.jobscheduler.services.JobPayloadSerializer;
+
+@Component
+public class CohActionSerializer implements JobPayloadSerializer<CohJobPayload> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String serialize(CohJobPayload payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Cannot serialize CohJobPayload for case id "
+                    + "[" + payload.getCaseId() + "] online hearing id [" + payload.getOnlineHearingId() + "]");
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/scheduler/CohJobPayload.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/scheduler/CohJobPayload.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.sscs.service.scheduler;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@Builder
+@EqualsAndHashCode
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CohJobPayload {
+    private long caseId;
+    private String onlineHearingId;
+
+    public CohJobPayload(@JsonProperty("case_id")long caseId, @JsonProperty("online_hearing_id")String onlineHearingId) {
+        this.caseId = caseId;
+        this.onlineHearingId = onlineHearingId;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -164,6 +164,10 @@ reminder:
   hearingReminder.beforeFirst.seconds: 604800
   hearingReminder.beforeSecond.seconds: 86400
 
+outOfHours:
+  startHour: ${HOURS_START_TIME:9}
+  endHour: ${HOURS_END_TIME:17}
+
 feign:
   client:
     config:

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/NotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/NotificationHandlerTest.java
@@ -1,0 +1,115 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.net.UnknownHostException;
+import java.time.ZonedDateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType;
+import uk.gov.hmcts.reform.sscs.exception.NotificationClientRuntimeException;
+import uk.gov.hmcts.reform.sscs.exception.NotificationServiceException;
+import uk.gov.hmcts.reform.sscs.factory.NotificationWrapper;
+import uk.gov.hmcts.reform.sscs.jobscheduler.model.Job;
+import uk.gov.hmcts.reform.sscs.jobscheduler.services.JobScheduler;
+import uk.gov.hmcts.reform.sscs.service.reminder.JobGroupGenerator;
+import uk.gov.service.notify.NotificationClientException;
+
+public class NotificationHandlerTest {
+
+    public static final NotificationEventType A_NOTIFICATION_THAT_CAN_TRIGGER_OUT_OF_HOURS = NotificationEventType.SYA_APPEAL_CREATED_NOTIFICATION;
+    public static final NotificationEventType A_NOTIFICATION_THAT_CANNOT_TRIGGER_OUT_OF_HOURS = NotificationEventType.QUESTION_ROUND_ISSUED_NOTIFICATION;
+    private OutOfHoursCalculator outOfHoursCalculator;
+    private JobScheduler jobScheduler;
+    private JobGroupGenerator jobGroupGenerator;
+    private NotificationWrapper notificationWrapper;
+    private NotificationHandler.SendNotification sendNotification;
+    private NotificationHandler underTest;
+
+    @Before
+    public void setUp() {
+        outOfHoursCalculator = mock(OutOfHoursCalculator.class);
+        jobScheduler = mock(JobScheduler.class);
+        jobGroupGenerator = mock(JobGroupGenerator.class);
+        notificationWrapper = mock(NotificationWrapper.class);
+        sendNotification = mock(NotificationHandler.SendNotification.class);
+
+        underTest = new NotificationHandler(outOfHoursCalculator, jobScheduler, jobGroupGenerator);
+    }
+
+    @Test
+    public void shouldSendNotificationIfNotificationTypeCanBeSentOutOfHouseAndItIsInHours() throws NotificationClientException {
+        canSendNotification(A_NOTIFICATION_THAT_CAN_TRIGGER_OUT_OF_HOURS, false);
+    }
+
+    @Test
+    public void shouldSendNotificationIfNotificationTypeCanBeSentOutOfHouseAndItIsOutOfHours() throws NotificationClientException {
+        canSendNotification(A_NOTIFICATION_THAT_CAN_TRIGGER_OUT_OF_HOURS, true);
+    }
+
+    @Test
+    public void shouldSendNotificationIfNotificationTypeCannotBeSentOutOfHouseAndItIsInHours() throws NotificationClientException {
+        canSendNotification(A_NOTIFICATION_THAT_CANNOT_TRIGGER_OUT_OF_HOURS, false);
+    }
+
+    @Test
+    public void shouldNotSendNotificationIfNotificationTypeCannotBeSentOutOfHouseAndItIsOutOfHours() throws NotificationClientException {
+        when(notificationWrapper.getNotificationType()).thenReturn(A_NOTIFICATION_THAT_CANNOT_TRIGGER_OUT_OF_HOURS);
+        String payload = "payload";
+        when(notificationWrapper.getSchedulerPayload()).thenReturn(payload);
+        String caseId = "caseId";
+        when(notificationWrapper.getCaseId()).thenReturn(caseId);
+        when(outOfHoursCalculator.isItOutOfHours()).thenReturn(true);
+        ZonedDateTime whenToScheduleJob = ZonedDateTime.now();
+        when(outOfHoursCalculator.getStartOfNextInHoursPeriod()).thenReturn(whenToScheduleJob);
+        String group = "group";
+        when(jobGroupGenerator.generate(caseId, A_NOTIFICATION_THAT_CANNOT_TRIGGER_OUT_OF_HOURS.getId())).thenReturn(group);
+
+        underTest.sendNotification(notificationWrapper, "someTemplate", "Email", sendNotification);
+
+        verifyZeroInteractions(sendNotification);
+        ArgumentCaptor<Job> argument = ArgumentCaptor.forClass(Job.class);
+        verify(jobScheduler).schedule(argument.capture());
+
+        Job value = argument.getValue();
+        assertThat(value.triggerAt, is(whenToScheduleJob));
+        assertThat(value.group, is(group));
+        assertThat(value.name, is(A_NOTIFICATION_THAT_CANNOT_TRIGGER_OUT_OF_HOURS.getId()));
+        assertThat(value.payload, is(payload));
+    }
+
+    private void canSendNotification(NotificationEventType notificationEventType, boolean isOutOfHours) throws NotificationClientException {
+        when(notificationWrapper.getNotificationType()).thenReturn(notificationEventType);
+        when(outOfHoursCalculator.isItOutOfHours()).thenReturn(isOutOfHours);
+
+        underTest.sendNotification(notificationWrapper, "someTemplate", "Email", sendNotification);
+
+        verify(sendNotification).send();
+        verifyZeroInteractions(jobScheduler);
+    }
+
+    @Test(expected = NotificationClientRuntimeException.class)
+    public void shouldThrowNotificationClientRuntimeExceptionForAnyNotificationException() throws Exception {
+        when(notificationWrapper.getNotificationType()).thenReturn(A_NOTIFICATION_THAT_CAN_TRIGGER_OUT_OF_HOURS);
+        when(outOfHoursCalculator.isItOutOfHours()).thenReturn(false);
+        doThrow(new NotificationClientException(new UnknownHostException()))
+                .when(sendNotification)
+                .send();
+
+        underTest.sendNotification(notificationWrapper, "someTemplate", "Email", sendNotification);
+    }
+
+    @Test(expected = NotificationServiceException.class)
+    public void shouldCorrectlyHandleAGovNotifyException() throws Exception {
+        when(notificationWrapper.getNotificationType()).thenReturn(A_NOTIFICATION_THAT_CAN_TRIGGER_OUT_OF_HOURS);
+        when(outOfHoursCalculator.isItOutOfHours()).thenReturn(false);
+        doThrow(new NotificationClientException(new RuntimeException()))
+                .when(sendNotification)
+                .send();
+
+        underTest.sendNotification(notificationWrapper, "someTemplate", "Email", sendNotification);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/OutOfHoursCalculatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/OutOfHoursCalculatorTest.java
@@ -1,0 +1,80 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.junit.Test;
+
+public class OutOfHoursCalculatorTest {
+
+    public static final int START_HOUR = 9;
+    public static final int END_HOUR = 17;
+
+    @Test
+    public void isNotOutOfHours() {
+        ZonedDateTime now = nowAtHour(12);
+        boolean isOutOfHours = new OutOfHoursCalculator(new FixedDateTimeProvider(now), START_HOUR, END_HOUR).isItOutOfHours();
+
+        assertThat(isOutOfHours, is(false));
+    }
+
+    @Test
+    public void isNotOutOfHoursAtStartTime() {
+        ZonedDateTime now = nowAtHour(9);
+        boolean isOutOfHours = new OutOfHoursCalculator(new FixedDateTimeProvider(now), START_HOUR, END_HOUR).isItOutOfHours();
+
+        assertThat(isOutOfHours, is(false));
+    }
+
+    @Test
+    public void isOutOfHours() {
+        ZonedDateTime now = nowAtHour(20);
+        boolean isOutOfHours = new OutOfHoursCalculator(new FixedDateTimeProvider(now), START_HOUR, END_HOUR).isItOutOfHours();
+
+        assertThat(isOutOfHours, is(true));
+    }
+
+    @Test
+    public void isOutOfHoursAtEndTime() {
+        ZonedDateTime now = nowAtHour(17);
+        boolean isOutOfHours = new OutOfHoursCalculator(new FixedDateTimeProvider(now), START_HOUR, END_HOUR).isItOutOfHours();
+
+        assertThat(isOutOfHours, is(true));
+    }
+
+    @Test
+    public void getStartOfNextInHoursPeriodWhenItIsTheNextDay() {
+        ZonedDateTime now = nowAtHour(END_HOUR);
+        ZonedDateTime nextInHoursTime = new OutOfHoursCalculator(new FixedDateTimeProvider(now), START_HOUR, END_HOUR).getStartOfNextInHoursPeriod();
+
+        assertThat(nextInHoursTime, is(ZonedDateTime.of(2018, 9, 19, START_HOUR, 0, 0, 0, ZoneId.systemDefault())));
+    }
+
+    @Test
+    public void getStartOfNextInHoursPeriodWhenItIsTheSameDay() {
+        ZonedDateTime now = nowAtHour(1);
+        ZonedDateTime nextInHoursTime = new OutOfHoursCalculator(new FixedDateTimeProvider(now), START_HOUR, END_HOUR).getStartOfNextInHoursPeriod();
+
+        assertThat(nextInHoursTime, is(ZonedDateTime.of(2018, 9, 18, START_HOUR, 0, 0, 0, ZoneId.systemDefault())));
+    }
+
+    private ZonedDateTime nowAtHour(int hour) {
+        return ZonedDateTime.of(2018, 9, 18, hour, 0, 0, 0, ZoneId.systemDefault());
+    }
+
+    public static class FixedDateTimeProvider extends DateTimeProvider {
+
+        private final ZonedDateTime now;
+
+        public FixedDateTimeProvider(ZonedDateTime now) {
+            this.now = now;
+        }
+
+        @Override
+        public ZonedDateTime now() {
+            return now;
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/reminder/DwpResponseLateReminderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/reminder/DwpResponseLateReminderTest.java
@@ -31,7 +31,7 @@ public class DwpResponseLateReminderTest {
     @Mock
     private JobGroupGenerator jobGroupGenerator;
     @Mock
-    private JobScheduler<String> jobScheduler;
+    private JobScheduler jobScheduler;
 
     private DwpResponseLateReminder dwpResponseLateReminder;
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/reminder/EvidenceReminderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/reminder/EvidenceReminderTest.java
@@ -31,7 +31,7 @@ public class EvidenceReminderTest {
     @Mock
     private JobGroupGenerator jobGroupGenerator;
     @Mock
-    private JobScheduler<String> jobScheduler;
+    private JobScheduler jobScheduler;
 
     private EvidenceReminder evidenceReminder;
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/reminder/HearingHoldingReminderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/reminder/HearingHoldingReminderTest.java
@@ -30,7 +30,7 @@ public class HearingHoldingReminderTest {
     @Mock
     private JobGroupGenerator jobGroupGenerator;
     @Mock
-    private JobScheduler<String> jobScheduler;
+    private JobScheduler jobScheduler;
 
     private HearingHoldingReminder hearingHoldingReminder;
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/reminder/HearingReminderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/reminder/HearingReminderTest.java
@@ -25,7 +25,7 @@ public class HearingReminderTest {
     @Mock
     private JobGroupGenerator jobGroupGenerator;
     @Mock
-    private JobScheduler<String> jobScheduler;
+    private JobScheduler jobScheduler;
 
     private HearingReminder hearingReminder;
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/scheduler/CcdActionExecutorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/scheduler/CcdActionExecutorTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.deserialize.SscsCaseDataWrapperDeserializer;
 import uk.gov.hmcts.reform.sscs.domain.SscsCaseDataWrapper;
@@ -18,9 +17,9 @@ import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
 import uk.gov.hmcts.reform.sscs.service.NotificationService;
 
-public class ActionExecutorTest {
+public class CcdActionExecutorTest {
 
-    private ActionExecutor actionExecutor;
+    private CcdActionExecutor ccdActionExecutor;
 
     @Mock
     private NotificationService notificationService;
@@ -32,7 +31,6 @@ public class ActionExecutorTest {
     private SscsCaseDataWrapperDeserializer deserializer;
 
     private CaseDetails caseDetails;
-    private SscsCaseDetails sscsCaseDetails;
     private SscsCaseDataWrapper wrapper;
     private SscsCaseData newSscsCaseData;
 
@@ -42,7 +40,7 @@ public class ActionExecutorTest {
     public void setup() {
         initMocks(this);
 
-        actionExecutor = new ActionExecutor(notificationService, ccdService, deserializer, idamService);
+        ccdActionExecutor = new CcdActionExecutor(notificationService, ccdService, deserializer, idamService);
 
         caseDetails = CaseDetails.builder().caseTypeId("123").build();
 
@@ -58,9 +56,8 @@ public class ActionExecutorTest {
     public void givenAReminderIsTriggered_thenActionExecutorShouldProcessTheJob() {
         when(ccdService.getByCaseId(eq(123456L), eq(idamTokens))).thenReturn(caseDetails);
         when(deserializer.buildSscsCaseDataWrapper(any())).thenReturn(wrapper);
-        when(ccdService.updateCase(eq(newSscsCaseData), eq(123456L), eq(EVIDENCE_REMINDER_NOTIFICATION.getId()), any(), any(), eq(idamTokens))).thenReturn(sscsCaseDetails);
 
-        actionExecutor.execute("1", "group", EVIDENCE_REMINDER_NOTIFICATION.getId(), "123456");
+        ccdActionExecutor.execute("1", "group", EVIDENCE_REMINDER_NOTIFICATION.getId(), "123456");
 
         verify(notificationService, times(1)).createAndSendNotification(new CcdNotificationWrapper(wrapper));
         verify(ccdService, times(1)).updateCase(any(), any(), any(), any(), any(), any());

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/scheduler/CohActionDeserializerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/scheduler/CohActionDeserializerTest.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.sscs.service.scheduler;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+import java.util.UUID;
+import org.junit.Test;
+
+public class CohActionDeserializerTest {
+    @Test
+    public void canDeserializePayload() {
+        String onlineHearingId = UUID.randomUUID().toString();
+        long caseId = 123L;
+        String payload = "{\"case_id\": " + caseId + ", \"online_hearing_id\": \"" + onlineHearingId + "\"}";
+        CohJobPayload deserialize = new CohActionDeserializer().deserialize(payload);
+
+        assertThat(deserialize.getCaseId(), is(equalTo(caseId)));
+        assertThat(deserialize.getOnlineHearingId(), is(equalTo(onlineHearingId)));
+    }
+
+    @Test
+    public void canSerializeThenDeserializePayload() {
+        String onlineHearingId = UUID.randomUUID().toString();
+        long caseId = 123L;
+
+        CohJobPayload expectedCohJobPayload = new CohJobPayload(caseId, onlineHearingId);
+
+        String payload = new CohActionSerializer().serialize(expectedCohJobPayload);
+        CohJobPayload cohJobPayload = new CohActionDeserializer().deserialize(payload);
+
+        assertThat(cohJobPayload, is(equalTo(expectedCohJobPayload)));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/scheduler/CohActionExecutorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/scheduler/CohActionExecutorTest.java
@@ -1,0 +1,67 @@
+package uk.gov.hmcts.reform.sscs.service.scheduler;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType.EVIDENCE_REMINDER_NOTIFICATION;
+
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
+import uk.gov.hmcts.reform.sscs.deserialize.SscsCaseDataWrapperDeserializer;
+import uk.gov.hmcts.reform.sscs.domain.SscsCaseDataWrapper;
+import uk.gov.hmcts.reform.sscs.factory.CohNotificationWrapper;
+import uk.gov.hmcts.reform.sscs.idam.IdamService;
+import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
+import uk.gov.hmcts.reform.sscs.service.NotificationService;
+
+public class CohActionExecutorTest {
+
+    private CohActionExecutor cohActionExecutor;
+
+    @Mock
+    private NotificationService notificationService;
+    @Mock
+    private IdamService idamService;
+    @Mock
+    private CcdService ccdService;
+    @Mock
+    private SscsCaseDataWrapperDeserializer deserializer;
+
+    private CaseDetails caseDetails;
+    private SscsCaseDataWrapper wrapper;
+    private SscsCaseData newSscsCaseData;
+
+    private IdamTokens idamTokens;
+
+    @Before
+    public void setup() {
+        initMocks(this);
+
+        cohActionExecutor = new CohActionExecutor(notificationService, ccdService, deserializer, idamService);
+
+        caseDetails = CaseDetails.builder().caseTypeId("123").build();
+
+        newSscsCaseData = SscsCaseData.builder().build();
+
+        wrapper = SscsCaseDataWrapper.builder().newSscsCaseData(newSscsCaseData).notificationEventType(EVIDENCE_REMINDER_NOTIFICATION).build();
+
+        idamTokens = IdamTokens.builder().build();
+        when(idamService.getIdamTokens()).thenReturn(idamTokens);
+    }
+
+    @Test
+    public void givenAReminderIsTriggered_thenActionExecutorShouldProcessTheJob() {
+        when(ccdService.getByCaseId(eq(123456L), eq(idamTokens))).thenReturn(caseDetails);
+        when(deserializer.buildSscsCaseDataWrapper(any())).thenReturn(wrapper);
+
+        String onlineHearingId = UUID.randomUUID().toString();
+        cohActionExecutor.execute("1", "group", EVIDENCE_REMINDER_NOTIFICATION.getId(), new CohJobPayload(123456L, onlineHearingId));
+
+        verify(notificationService, times(1)).createAndSendNotification(new CohNotificationWrapper(onlineHearingId, wrapper));
+        verify(ccdService, times(1)).updateCase(any(), any(), any(), any(), any(), any());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/scheduler/CohActionSerializerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/scheduler/CohActionSerializerTest.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.sscs.service.scheduler;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+import java.util.UUID;
+import org.junit.Test;
+
+public class CohActionSerializerTest {
+
+    @Test
+    public void canSerialize() {
+        int caseId = 123;
+        String onlineHearingId = UUID.randomUUID().toString();
+        String payload = new CohActionSerializer().serialize(new CohJobPayload(caseId, onlineHearingId));
+
+        assertThat(payload, is(equalTo("{\"caseId\":" + caseId + ",\"onlineHearingId\":\"" + onlineHearingId + "\"}")));
+    }
+}


### PR DESCRIPTION
If we receive a callback to send COH notifications out of hours use the
reminder service to send when we are back in hours.

Configurable on a per NotificationEventType basis.