### PR TITLE
SSCS-3974 Fix links in texts

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -6,5 +6,6 @@ sscs_track_your_appeal_link = "https://track-appeal.nonprod.platform.hmcts.net/t
 hearing_info_link = "https://track-appeal.nonprod.platform.hmcts.net/abouthearing/appeal_id"
 claiming_expenses_link = "https://track-appeal.nonprod.platform.hmcts.net/expenses/appeal_id"
 online_hearing_link = "https://sscs-cor-frontend-aat.service.core-compute-aat.internal/login"
+online_hearing_link = "https://sscs-cor-frontend-aat-staging.service.core-compute-aat.internal/login"
 
 idam_redirect_url = "https://evidence-sharing-preprod.sscs.reform.hmcts.net"

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -5,6 +5,7 @@ sscs_manage_emails_link = "https://track-appeal.preview.platform.hmcts.net/manag
 sscs_track_your_appeal_link = "https://track-appeal.preview.platform.hmcts.net/trackyourappeal/appeal_id"
 hearing_info_link = "https://track-appeal.preview.platform.hmcts.net/abouthearing/appeal_id"
 claiming_expenses_link = "https://track-appeal.preview.platform.hmcts.net/expenses/appeal_id"
+online_hearing_link = "https://sscs-cor-frontend-aat-staging.service.core-compute-aat.internal/login"
 
 root_logging_level = "DEBUG"
 log_level_spring_web = "DEBUG"


### PR DESCRIPTION
This might be bacause gov notify expects links to start with https and
we have not been setting this for real yet so was http.