### PR TITLE
Optimise docker image build layers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!build/libs/track-your-appeal-notifications.jar

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 *
 !build/libs/track-your-appeal-notifications.jar
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM hmcts/cnp-java-base:openjdk-jre-8-alpine-1.2
 
-COPY build/libs/track-your-appeal-notifications.jar ./
+ENV APP track-your-appeal-notifications.jar
+ENV APPLICATION_TOTAL_MEMORY 2048M
+ENV APPLICATION_SIZE_ON_DISK_IN_MB 100
+
+COPY build/libs/track-your-appeal-notifications.jar /opt/app/
 
 EXPOSE 8081
-
-CMD ["/usr/bin/java", "-jar", "/opt/app/track-your-appeal-notifications.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hmcts/cnp-java-base:openjdk-jre-8-alpine-1.2
+FROM hmcts/cnp-java-base:openjdk-8u181-jre-alpine3.8-1.0
 
 ENV APP track-your-appeal-notifications.jar
 ENV APPLICATION_TOTAL_MEMORY 2048M

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM openjdk:8-jre
-
-WORKDIR /opt/app
+FROM hmcts/cnp-java-base:openjdk-jre-8-alpine-1.2
 
 COPY build/libs/track-your-appeal-notifications.jar ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM openjdk:8-jre
 
-COPY build/libs/track-your-appeal-notifications.jar /opt/app/
-
 WORKDIR /opt/app
+
+COPY build/libs/track-your-appeal-notifications.jar ./
 
 EXPOSE 8081
 


### PR DESCRIPTION
JIRA ticket: [CNP-1104](https://tools.hmcts.net/jira/browse/CNP-1104)

Hello, this PR adds the following enhancements:
- improve the ordering of the docker image build layer 
- prepare for future ACR cache optimisations.

This is part of a general [pipelines optimisations initiative](https://tools.hmcts.net/confluence/display/CNP/Pipeline+optimisations) and should not impact the current builds.
