### PR TITLE
Upgraded dependency for c3p0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ dependencyManagement {
 repositories {
 
     mavenLocal()
-    
+
     maven {
         url "https://dl.bintray.com/hmcts/hmcts-maven"
     }
@@ -208,7 +208,7 @@ dependencies {
     compile group: 'com.opencsv', name: 'opencsv', version: '4.4'
     compile group: 'commons-io', name: 'commons-io', version: '2.6'
 
-    compile group: 'com.mchange', name: 'c3p0', version: '0.9.5.2'
+    compile group: 'com.mchange', name: 'c3p0', version: '0.9.5.3'
     compile group: 'org.flywaydb', name: 'flyway-core', version: '5.1.0'
     compile group: 'org.postgresql', name: 'postgresql', version: '42.2.2'
 
@@ -234,7 +234,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '1.0.4'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.133'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '0.0.100'
-    
+
     compile group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.12.0-RELEASE'
     compile group: 'io.github.openfeign', name: 'feign-httpclient', version: '10.0.1'
     compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.4.1'


### PR DESCRIPTION
This is meant to solve the following error:

```
One or more dependencies were identified with known vulnerabilities:


c3p0-0.9.5.2.jar (com.mchange:c3p0:0.9.5.2, cpe:/a:mchange:c3p0:0.9.5.2) : CVE-2018-20433
```