### PR TITLE
Set online_hearing_link to be the respective prod slot not the staging slot.

### DIFF
--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,3 +1,4 @@
+management_security_enabled = "false"
 infrastructure_env = "preprod"
 
 evidence_submission_info_link = "https://track-appeal.demo.platform.hmcts.net/evidence/appeal_id"
@@ -8,3 +9,4 @@ claiming_expenses_link = "https://track-appeal.demo.platform.hmcts.net/expenses/
 online_hearing_link = "https://sscs-cor-frontend-demo.service.core-compute-demo.internal"
 
 idam_redirect_url = "https://evidence-sharing-preprod.sscs.reform.hmcts.net"
+notification_key = "notification-key-demo"

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -5,5 +5,6 @@ sscs_manage_emails_link = "https://track-appeal.demo.platform.hmcts.net/manage-e
 sscs_track_your_appeal_link = "https://track-appeal.demo.platform.hmcts.net/trackyourappeal/appeal_id"
 hearing_info_link = "https://track-appeal.demo.platform.hmcts.net/abouthearing/appeal_id"
 claiming_expenses_link = "https://track-appeal.demo.platform.hmcts.net/expenses/appeal_id"
+online_hearing_link = "https://sscs-cor-frontend-demo.service.core-compute-demo.internal"
 
 idam_redirect_url = "https://evidence-sharing-preprod.sscs.reform.hmcts.net"

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -5,7 +5,7 @@ sscs_manage_emails_link = "https://track-appeal.preview.platform.hmcts.net/manag
 sscs_track_your_appeal_link = "https://track-appeal.nonprod.platform.hmcts.net/trackyourappeal/appeal_id"
 hearing_info_link = "https://track-appeal.preview.platform.hmcts.net/abouthearing/appeal_id"
 claiming_expenses_link = "https://track-appeal.preview.platform.hmcts.net/expenses/appeal_id"
-online_hearing_link = "https://sscs-cor-frontend-aat-staging.service.core-compute-aat.internal"
+online_hearing_link = "https://sscs-cor-frontend-aat.service.core-compute-aat.internal"
 
 root_logging_level = "DEBUG"
 log_level_spring_web = "DEBUG"

--- a/kubernetes/deployment.template.yaml
+++ b/kubernetes/deployment.template.yaml
@@ -64,7 +64,7 @@ spec:
         - name: EMAIL_MAC_SECRET_TEXT
           value: ${EMAIL_MAC_SECRET_TEXT}
         - name: ONLINE_HEARING_LINK
-          value: https://sscs-cor-frontend-aat-staging.service.core-compute-aat.internal
+          value: https://sscs-cor-frontend-aat.service.core-compute-aat.internal
         - name: JOB_SCHEDULER_DB_HOST
           value: postgres
         - name: JOB_SCHEDULER_DB_PORT


### PR DESCRIPTION
Links to COR in notifications were to the staging slot not prod in demo. Adding this back to master and merging in other changes I think we need from the master branch.