### PR TITLE
feign-httpclient upgrade does not work. Downgrade it back again.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,7 +236,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '0.0.100'
 
     compile group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.14.0-RELEASE'
-    compile group: 'io.github.openfeign', name: 'feign-httpclient', version: '10.1.0'
+    compile group: 'io.github.openfeign', name: 'feign-httpclient', version: '10.0.1'
     compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.4.1'
 
 


### PR DESCRIPTION

```
Caused by: java.lang.NoSuchMethodError: feign.Request.httpMethod()Lfeign/Request$HttpMethod;
        at feign.httpclient.ApacheHttpClient.toHttpUriRequest(ApacheHttpClient.java:91)
        at feign.httpclient.ApacheHttpClient.execute(ApacheHttpClient.java:81)
        at feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:97)
        at feign.SynchronousMethodHandler.invoke(SynchronousMethodHandler.java:76)
        at feign.ReflectiveFeign$FeignInvocationHandler.invoke(ReflectiveFeign.java:103)
        at com.sun.proxy.$Proxy138.getServiceName(Unknown Source)
        at uk.gov.hmcts.reform.sscs.service.AuthorisationService.authorise(AuthorisationService.java:26)
        at uk.gov.hmcts.reform.sscs.controller.NotificationController.sendNotification(NotificationController.java:50)
```