### PR TITLE
SSCS-5217 RPC NPE fix for scottish SC numbers

### DIFF
--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/NotificationsIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/NotificationsIt.java
@@ -2042,6 +2042,27 @@ public class NotificationsIt {
     }
 
     @Test
+    public void givenAnUnknownRpcCase_thenDoNotProcessNotifications() throws Exception {
+        String path = getClass().getClassLoader().getResource("json/ccdResponseWithNoOldCaseRef.json").getFile();
+        String json = FileUtils.readFileToString(new File(path), StandardCharsets.UTF_8.name());
+
+        json = json.replace("appealReceived", "appealCreated");
+        json = json.replace("SC022", "SC948");
+
+        json = updateEmbeddedJson(json, "No", "case_details", "case_data", "subscriptions", "appellantSubscription", "subscribeEmail");
+        json = updateEmbeddedJson(json, "No", "case_details", "case_data", "subscriptions", "appellantSubscription", "subscribeSms");
+        json = updateEmbeddedJson(json, "No", "case_details", "case_data", "subscriptions", "representativeSubscription", "subscribeEmail");
+        json = updateEmbeddedJson(json, "No", "case_details", "case_data", "subscriptions", "representativeSubscription", "subscribeSms");
+        json = updateEmbeddedJson(json, "No", "case_details_before", "case_data", "subscriptions", "representativeSubscription", "subscribeSms");
+
+        HttpServletResponse response = getResponse(getRequestWithAuthHeader(json));
+
+        assertHttpStatus(response, HttpStatus.OK);
+        verify(notificationClient, never()).sendEmail(any(), any(), any(), any());
+        verify(notificationClient, never()).sendSms(any(), any(), any(), any(), any());
+    }
+
+    @Test
     public void shouldReturn400WhenAuthHeaderIsMissing() throws Exception {
         HttpServletResponse response = getResponse(getRequestWithoutAuthHeader(json));
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
@@ -240,13 +240,15 @@ public class Personalisation<E extends NotificationWrapper> {
         } else {
             rpc = regionalProcessingCenterService.getByScReferenceCode(ccdResponse.getCaseReference());
         }
-        personalisation.put(REGIONAL_OFFICE_NAME_LITERAL, rpc.getAddress1());
-        personalisation.put(SUPPORT_CENTRE_NAME_LITERAL, rpc.getAddress2());
-        personalisation.put(ADDRESS_LINE_LITERAL, rpc.getAddress3());
-        personalisation.put(TOWN_LITERAL, rpc.getAddress4());
-        personalisation.put(COUNTY_LITERAL, rpc.getCity());
-        personalisation.put(POSTCODE_LITERAL, rpc.getPostcode());
-        personalisation.put(REGIONAL_OFFICE_POSTCODE_LITERAL, rpc.getPostcode());
+        if (rpc != null) {
+            personalisation.put(REGIONAL_OFFICE_NAME_LITERAL, rpc.getAddress1());
+            personalisation.put(SUPPORT_CENTRE_NAME_LITERAL, rpc.getAddress2());
+            personalisation.put(ADDRESS_LINE_LITERAL, rpc.getAddress3());
+            personalisation.put(TOWN_LITERAL, rpc.getAddress4());
+            personalisation.put(COUNTY_LITERAL, rpc.getCity());
+            personalisation.put(POSTCODE_LITERAL, rpc.getPostcode());
+            personalisation.put(REGIONAL_OFFICE_POSTCODE_LITERAL, rpc.getPostcode());
+        }
 
         return personalisation;
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
@@ -522,6 +522,25 @@ public class PersonalisationTest {
     }
 
     @Test
+    public void shouldNotPopulateRegionalProcessingCenterIfRpcCannotBeFound() {
+
+        SscsCaseData response = SscsCaseData.builder().regionalProcessingCenter(null).build();
+
+        when(regionalProcessingCenterService.getByScReferenceCode("SC/1234/5")).thenReturn(null);
+
+        Map<String, String> result = personalisation.setEvidenceProcessingAddress(new HashMap<>(), response);
+
+        verify(regionalProcessingCenterService, never()).getByScReferenceCode(anyString());
+
+        assertNull(result.get(REGIONAL_OFFICE_NAME_LITERAL));
+        assertNull(result.get(SUPPORT_CENTRE_NAME_LITERAL));
+        assertNull(result.get(ADDRESS_LINE_LITERAL));
+        assertNull(result.get(TOWN_LITERAL));
+        assertNull(result.get(COUNTY_LITERAL));
+        assertNull(result.get(POSTCODE_LITERAL));
+    }
+
+    @Test
     public void shouldPopulateHearingContactDateFromCcdCaseIfPresent() {
 
         SscsCaseDataWrapper wrapper = SscsCaseDataWrapper.builder().newSscsCaseData(SscsCaseData.builder().build()).build();

--- a/src/test/resources/json/ccdResponseWithNoOldCaseRef.json
+++ b/src/test/resources/json/ccdResponseWithNoOldCaseRef.json
@@ -178,18 +178,6 @@
           "tya": "232929249492"
         }
       },
-      "region" : "CARDIFF",
-      "regionalProcessingCenter" : {
-        "name" : "CARDIFF",
-        "address1" : "HM Courts & Tribunals Service",
-        "address2" : "Social Security & Child Support Appeals",
-        "address3" : "Eastgate House",
-        "address4" : "Newport Road",
-        "city" : "CARDIFF",
-        "postcode" : "CF24 0AB",
-        "phoneNumber" : "0300 123 1142",
-        "faxNumber" : "0870 739 4438"
-      },
       "hearings": [{
         "id": "1234",
         "value": {


### PR DESCRIPTION
- When the SC number was a Scottish number and the RPC was unknown, then a NPE was throw when building the RPC personalisation details
