### PR TITLE
SSCS-5383 Log errors when actions fail

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -161,4 +161,11 @@
    ]]></notes>
     <cve>CVE-2017-16224</cve>
   </suppress>
+  <suppress>
+    <notes>
+      False positive issue says Spring Framework version 5.0.5 when used in combination with any versions of Spring
+      Security contains an authorization bypass but this project is not using Spring framework 5.0.5
+    </notes>
+    <cve>CVE-2018-1258</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
If we run an action and it fails we currently can't always tell which
case it was associated with. Add a log statement in the base action
executor to log the case id for any exceptions thrown in the
ActionExecutor.