### PR TITLE
SSCS-5512 Bundled Rep letters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -237,7 +237,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.0.0'
 
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '2.0.14'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.0.4'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.0.5'
 
     compile group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.14.2-RELEASE'
     compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.8.0'

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/service/NotificationServiceForSubscriptionUpdatedTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/service/NotificationServiceForSubscriptionUpdatedTest.java
@@ -109,6 +109,9 @@ public class NotificationServiceForSubscriptionUpdatedTest {
     @Autowired
     private NotificationHandler notificationHandler;
 
+    @Autowired
+    private BundledLetterTemplateUtil bundledLetterTemplateUtil;
+
     @Mock
     private NotificationSender notificationSender;
 
@@ -146,8 +149,7 @@ public class NotificationServiceForSubscriptionUpdatedTest {
 
     private NotificationService getNotificationService() {
         SendNotificationService sendNotificationService = new SendNotificationService(notificationSender,
-                evidenceManagementService, sscsGeneratePdfService, notificationHandler, notificationValidService);
-        ReflectionTestUtils.setField(sendNotificationService, "strikeOutLetterTemplate", "/templates/non_compliant_case_letter_template.html");
+                evidenceManagementService, sscsGeneratePdfService, notificationHandler, notificationValidService, bundledLetterTemplateUtil);
         ReflectionTestUtils.setField(sendNotificationService, "bundledLettersOn", false);
         ReflectionTestUtils.setField(sendNotificationService, "lettersOn", false);
         return new NotificationService(notificationFactory, reminderService,

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/CohNotificationsIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/CohNotificationsIt.java
@@ -112,6 +112,10 @@ public class CohNotificationsIt {
     @Autowired
     private NotificationConfig notificationConfig;
 
+    @Autowired
+    private BundledLetterTemplateUtil bundledLetterTemplateUtil;
+
+
     @Mock
     private SscsGeneratePdfService sscsGeneratePdfService;
 
@@ -121,7 +125,7 @@ public class CohNotificationsIt {
     public void setup() throws Exception {
         NotificationSender sender = new NotificationSender(notificationClient, null, notificationBlacklist);
 
-        SendNotificationService sendNotificationService = new SendNotificationService(sender, evidenceManagementService, sscsGeneratePdfService, notificationHandler, notificationValidService);
+        SendNotificationService sendNotificationService = new SendNotificationService(sender, evidenceManagementService, sscsGeneratePdfService, notificationHandler, notificationValidService, bundledLetterTemplateUtil);
         ReflectionTestUtils.setField(sendNotificationService, "bundledLettersOn", true);
         ReflectionTestUtils.setField(sendNotificationService, "lettersOn", true);
 

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/NotificationsIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/NotificationsIt.java
@@ -110,6 +110,9 @@ public class NotificationsIt {
     @Autowired
     private NotificationConfig notificationConfig;
 
+    @Autowired
+    private BundledLetterTemplateUtil bundledLetterTemplateUtil;
+
     @Mock
     private EvidenceManagementService evidenceManagementService;
 
@@ -126,9 +129,8 @@ public class NotificationsIt {
     public void setup() throws Exception {
         NotificationSender sender = new NotificationSender(notificationClient, null, notificationBlacklist);
 
-        SendNotificationService sendNotificationService = new SendNotificationService(sender, evidenceManagementService, sscsGeneratePdfService, notificationHandler, notificationValidService);
-        ReflectionTestUtils.setField(sendNotificationService, "strikeOutLetterTemplate", "/templates/strike_out_letter_template.html");
-        ReflectionTestUtils.setField(sendNotificationService, "directionNoticeLetterTemplate", "/templates/direction_notice_letter_template.html");
+        SendNotificationService sendNotificationService = new SendNotificationService(sender, evidenceManagementService, sscsGeneratePdfService, notificationHandler, notificationValidService, bundledLetterTemplateUtil);
+
         ReflectionTestUtils.setField(sendNotificationService, "bundledLettersOn", true);
         ReflectionTestUtils.setField(sendNotificationService, "lettersOn", true);
 

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/OutOfHoursIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/OutOfHoursIt.java
@@ -121,6 +121,9 @@ public class OutOfHoursIt {
     @Autowired
     private JobGroupGenerator jobGroupGenerator;
 
+    @Autowired
+    private BundledLetterTemplateUtil bundledLetterTemplateUtil;
+
     @Mock
     private SscsGeneratePdfService sscsGeneratePdfService;
 
@@ -132,7 +135,7 @@ public class OutOfHoursIt {
     public void setup() throws Exception {
         NotificationSender sender = new NotificationSender(notificationClient, null, notificationBlacklist);
 
-        SendNotificationService sendNotificationService = new SendNotificationService(sender, evidenceManagementService, sscsGeneratePdfService, notificationHandler, notificationValidService);
+        SendNotificationService sendNotificationService = new SendNotificationService(sender, evidenceManagementService, sscsGeneratePdfService, notificationHandler, notificationValidService, bundledLetterTemplateUtil);
         ReflectionTestUtils.setField(sendNotificationService, "bundledLettersOn", true);
 
         outOfHoursCalculator = mock(OutOfHoursCalculator.class);

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/BundledLetterTemplateUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/BundledLetterTemplateUtil.java
@@ -1,0 +1,54 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import static uk.gov.hmcts.reform.sscs.config.SubscriptionType.REPRESENTATIVE;
+import static uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType.DIRECTION_ISSUED;
+import static uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType.STRUCK_OUT;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.config.SubscriptionType;
+import uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType;
+
+@Component
+public class BundledLetterTemplateUtil {
+
+    private final String strikeOutLetterTemplate;
+    private final String strikeOutLetterTemplateRep;
+    private final String directionNoticeLetterTemplate;
+    private final String directionNoticeLetterTemplateRep;
+
+    public BundledLetterTemplateUtil(
+            @Value("${strikeOutLetterTemplate.appelant.appeal.html.template.path}") String strikeOutLetterTemplate,
+            @Value("${strikeOutLetterTemplate.rep.appeal.html.template.path}") String strikeOutLetterTemplateRep,
+            @Value("${directionNoticeLetterTemplate.appelant.appeal.html.template.path}") String directionNoticeLetterTemplate,
+            @Value("${directionNoticeLetterTemplate.rep.appeal.html.template.path}") String directionNoticeLetterTemplateRep
+    ) {
+        this.strikeOutLetterTemplate = strikeOutLetterTemplate;
+        this.strikeOutLetterTemplateRep = strikeOutLetterTemplateRep;
+        this.directionNoticeLetterTemplate = directionNoticeLetterTemplate;
+        this.directionNoticeLetterTemplateRep = directionNoticeLetterTemplateRep;
+    }
+
+    public String getBundledLetterTemplate(NotificationEventType notificationEventType, SscsCaseData newSscsCaseData, SubscriptionType subscriptionType) {
+        if ((STRUCK_OUT.equals(notificationEventType)) && hasSscsDocument(newSscsCaseData)) {
+            if (REPRESENTATIVE.equals(subscriptionType)) {
+                return strikeOutLetterTemplateRep;
+            } else {
+                return strikeOutLetterTemplate;
+            }
+        } else if ((DIRECTION_ISSUED.equals(notificationEventType)) && (hasSscsDocument(newSscsCaseData))) {
+            if (REPRESENTATIVE.equals(subscriptionType)) {
+                return directionNoticeLetterTemplateRep;
+            } else {
+                return directionNoticeLetterTemplate;
+            }
+        }
+        return null;
+    }
+
+    private boolean hasSscsDocument(SscsCaseData newSscsCaseData) {
+        return newSscsCaseData.getSscsDocument() != null
+                && !newSscsCaseData.getSscsDocument().isEmpty();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/SendNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/SendNotificationService.java
@@ -53,12 +53,7 @@ public class SendNotificationService {
     private final SscsGeneratePdfService sscsGeneratePdfService;
     private final NotificationHandler notificationHandler;
     private final NotificationValidService notificationValidService;
-
-    @Value("${strikeOutLetterTemplate.appeal.html.template.path}")
-    String strikeOutLetterTemplate;
-
-    @Value("${directionNoticeLetterTemplate.appeal.html.template.path}")
-    String directionNoticeLetterTemplate;
+    private final BundledLetterTemplateUtil bundledLetterTemplateUtil;
 
     @Autowired
     public SendNotificationService(
@@ -66,13 +61,15 @@ public class SendNotificationService {
             EvidenceManagementService evidenceManagementService,
             SscsGeneratePdfService sscsGeneratePdfService,
             NotificationHandler notificationHandler,
-            NotificationValidService notificationValidService
+            NotificationValidService notificationValidService,
+            BundledLetterTemplateUtil bundledLetterTemplateUtil
     ) {
         this.notificationSender = notificationSender;
         this.evidenceManagementService = evidenceManagementService;
         this.sscsGeneratePdfService = sscsGeneratePdfService;
         this.notificationHandler = notificationHandler;
         this.notificationValidService = notificationValidService;
+        this.bundledLetterTemplateUtil = bundledLetterTemplateUtil;
     }
 
     void sendEmailSmsLetterNotification(
@@ -96,14 +93,14 @@ public class SendNotificationService {
             }
 
             NotificationHandler.SendNotification sendNotification = () ->
-                notificationSender.sendSms(
-                        notification.getSmsTemplate(),
-                        notification.getMobile(),
-                        notification.getPlaceholders(),
-                        notification.getReference(),
-                        notification.getSmsSenderTemplate(),
-                        wrapper.getCaseId()
-                );
+                    notificationSender.sendSms(
+                            notification.getSmsTemplate(),
+                            notification.getMobile(),
+                            notification.getPlaceholders(),
+                            notification.getReference(),
+                            notification.getSmsSenderTemplate(),
+                            wrapper.getCaseId()
+                    );
             notificationHandler.sendNotification(wrapper, notification.getSmsTemplate(), "SMS", sendNotification);
         }
     }
@@ -141,7 +138,7 @@ public class SendNotificationService {
             };
 
             if (bundledLettersOn && isBundledLetter(wrapper.getNotificationType())) {
-                sendBundledLetterNotification(wrapper, notification, getAddressToUseForLetter(wrapper, subscriptionType), getNameToUseForLetter(wrapper, subscriptionType));
+                sendBundledLetterNotification(wrapper, notification, getAddressToUseForLetter(wrapper, subscriptionType), getNameToUseForLetter(wrapper, subscriptionType), subscriptionType);
             } else if (hasLetterTemplate(notification)) {
                 notificationHandler.sendNotification(wrapper, notification.getLetterTemplate(), NOTIFICATION_TYPE_LETTER, sendNotification);
             }
@@ -157,7 +154,7 @@ public class SendNotificationService {
             };
 
             if (bundledLettersOn && isBundledLetter(wrapper.getNotificationType())) {
-                sendBundledLetterNotification(wrapper, notification, getAddressToUseForLetter(wrapper, subscriptionWithType.getSubscriptionType()), getNameToUseForLetter(wrapper, subscriptionWithType.getSubscriptionType()));
+                sendBundledLetterNotification(wrapper, notification, getAddressToUseForLetter(wrapper, subscriptionWithType.getSubscriptionType()), getNameToUseForLetter(wrapper, subscriptionWithType.getSubscriptionType()), subscriptionWithType.getSubscriptionType());
             } else {
                 notificationHandler.sendNotification(wrapper, notification.getLetterTemplate(), NOTIFICATION_TYPE_LETTER, sendNotification);
             }
@@ -166,8 +163,8 @@ public class SendNotificationService {
 
     public static String getRepSalutation(Representative rep) {
         if (null == rep.getName()
-            || null == rep.getName().getFirstName()
-            || null == rep.getName().getLastName()) {
+                || null == rep.getName().getFirstName()
+                || null == rep.getName().getLastName()) {
             return REP_SALUTATION;
         } else {
             return rep.getName().getFullNameNoTitle();
@@ -198,10 +195,10 @@ public class SendNotificationService {
             }
 
             notificationSender.sendLetter(
-                notification.getLetterTemplate(),
-                addressToUse,
-                notification.getPlaceholders(),
-                wrapper.getCaseId()
+                    notification.getLetterTemplate(),
+                    addressToUse,
+                    notification.getPlaceholders(),
+                    wrapper.getCaseId()
             );
         } else {
             log.warn("Attempting to send letter for case id: " + wrapper.getCaseId() + ", no address present");
@@ -210,11 +207,11 @@ public class SendNotificationService {
 
     private static boolean isValidLetterAddress(Address addressToUse) {
         return null != addressToUse
-            && null != addressToUse.getLine1()
-            && null != addressToUse.getPostcode();
+                && null != addressToUse.getLine1()
+                && null != addressToUse.getPostcode();
     }
 
-    private void sendBundledLetterNotification(NotificationWrapper wrapper, Notification notification, Address addressToUse, Name nameToUse) {
+    private void sendBundledLetterNotification(NotificationWrapper wrapper, Notification notification, Address addressToUse, Name nameToUse, SubscriptionType subscriptionType) {
         try {
             notification.getPlaceholders().put(AppConstants.LETTER_ADDRESS_LINE_1, addressToUse.getLine1());
             notification.getPlaceholders().put(AppConstants.LETTER_ADDRESS_LINE_2, addressToUse.getLine2());
@@ -224,7 +221,7 @@ public class SendNotificationService {
             notification.getPlaceholders().put(AppConstants.LETTER_NAME, nameToUse.getFullNameNoTitle());
 
             byte[] bundledLetter = buildBundledLetter(
-                    generateCoveringLetter(wrapper, notification),
+                    generateCoveringLetter(wrapper, notification, subscriptionType),
                     downloadAssociatedCasePdf(wrapper)
             );
 
@@ -242,11 +239,14 @@ public class SendNotificationService {
         }
     }
 
-    private byte[] generateCoveringLetter(NotificationWrapper wrapper, Notification notification) {
+    private byte[] generateCoveringLetter(NotificationWrapper wrapper, Notification notification, SubscriptionType subscriptionType) {
+        String bundledLetterTemplate = bundledLetterTemplateUtil.getBundledLetterTemplate(
+                wrapper.getNotificationType(), wrapper.getNewSscsCaseData(), subscriptionType
+        );
         return sscsGeneratePdfService.generatePdf(
-            getBundledLetterTemplate(wrapper.getNotificationType(), wrapper.getNewSscsCaseData()),
-            wrapper.getNewSscsCaseData(),
-            Long.parseLong(wrapper.getNewSscsCaseData().getCcdCaseId()), notification.getPlaceholders()
+                bundledLetterTemplate,
+                wrapper.getNewSscsCaseData(),
+                Long.parseLong(wrapper.getNewSscsCaseData().getCcdCaseId()), notification.getPlaceholders()
         );
     }
 
@@ -261,8 +261,8 @@ public class SendNotificationService {
             for (SscsDocument sscsDocument : newSscsCaseData.getSscsDocument()) {
                 if (filetype.equalsIgnoreCase(sscsDocument.getValue().getDocumentType())) {
                     associatedCasePdf = evidenceManagementService.download(
-                        URI.create(sscsDocument.getValue().getDocumentLink().getDocumentUrl()),
-                        DM_STORE_USER_ID
+                            URI.create(sscsDocument.getValue().getDocumentLink().getDocumentUrl()),
+                            DM_STORE_USER_ID
                     );
 
                     break;
@@ -280,24 +280,10 @@ public class SendNotificationService {
                 && !newSscsCaseData.getSscsDocument().isEmpty())) {
             filetype = STRIKE_OUT_NOTICE;
         } else if ((DIRECTION_ISSUED.equals(notificationEventType))
-            && (newSscsCaseData.getSscsDocument() != null
-            && !newSscsCaseData.getSscsDocument().isEmpty())) {
+                && (newSscsCaseData.getSscsDocument() != null
+                && !newSscsCaseData.getSscsDocument().isEmpty())) {
             filetype = DIRECTION_TEXT;
         }
         return filetype;
-    }
-
-    protected String getBundledLetterTemplate(NotificationEventType notificationEventType, SscsCaseData newSscsCaseData) {
-        String bundledLetterTemplate = null;
-        if ((STRUCK_OUT.equals(notificationEventType))
-            && (newSscsCaseData.getSscsDocument() != null
-            && !newSscsCaseData.getSscsDocument().isEmpty())) {
-            bundledLetterTemplate = strikeOutLetterTemplate;
-        } else if ((DIRECTION_ISSUED.equals(notificationEventType))
-            && (newSscsCaseData.getSscsDocument() != null
-            && !newSscsCaseData.getSscsDocument().isEmpty())) {
-            bundledLetterTemplate = directionNoticeLetterTemplate;
-        }
-        return bundledLetterTemplate;
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -344,8 +344,11 @@ appeal.email.subject: ${EMAIL_SUBJECT:Your appeal}
 appeal.email.message: ${EMAIL_MESSAGE:Your appeal has been created \nPlease do not respond to this email}
 
 appellant.appeal.html.template.path: /templates/appellant_appeal_template.html
-strikeOutLetterTemplate.appeal.html.template.path: /templates/strike_out_letter_template.html
+strikeOutLetterTemplate.appelant.appeal.html.template.path: /templates/strike_out_letter_template.html
+strikeOutLetterTemplate.rep.appeal.html.template.path: /templates/strike_out_letter_template_rep.html
 directionNoticeLetterTemplate.appeal.html.template.path: /templates/direction_notice_letter_template.html
+directionNoticeLetterTemplate.appelant.appeal.html.template.path: /templates/direction_notice_letter_template.html
+directionNoticeLetterTemplate.rep.appeal.html.template.path: /templates/direction_notice_letter_template_rep.html
 
 pdf.api.url: ${PDF_API_URL:http://localhost:5500}
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/BundledLetterTemplateUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/BundledLetterTemplateUtilTest.java
@@ -1,0 +1,93 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static uk.gov.hmcts.reform.sscs.config.SubscriptionType.*;
+import static uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType.DIRECTION_ISSUED;
+import static uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType.STRUCK_OUT;
+
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocument;
+import uk.gov.hmcts.reform.sscs.config.SubscriptionType;
+import uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType;
+
+public class BundledLetterTemplateUtilTest {
+
+    private String strikeoutTemplate;
+    private String strikeoutRepTemplate;
+    private String directionTemplate;
+    private String directionRepTemplate;
+    private BundledLetterTemplateUtil bundledLetterTemplateUtil;
+    private SscsCaseData sscsCaseDataWithDocument;
+    private SscsCaseData sscsCaseDataWithoutDocument;
+
+    @Before
+    public void setUp() {
+        strikeoutTemplate = "strikeoutTemplate";
+        strikeoutRepTemplate = "strikeoutRepTemplate";
+        directionTemplate = "directionTemplate";
+        directionRepTemplate = "directionRepTemplate";
+
+        bundledLetterTemplateUtil = new BundledLetterTemplateUtil(
+                strikeoutTemplate, strikeoutRepTemplate, directionTemplate, directionRepTemplate
+        );
+
+        sscsCaseDataWithDocument = SscsCaseData.builder().sscsDocument(Collections.singletonList(SscsDocument.builder().build())).build();
+        sscsCaseDataWithoutDocument = SscsCaseData.builder().build();
+    }
+
+    @Test
+    public void getStruckOutTemplateWhenAppellantStruckOutAndHaveDocumentTemplate() {
+        check(STRUCK_OUT, APPELLANT, strikeoutTemplate);
+    }
+
+    @Test
+    public void getStruckOutTemplateWhenAppointeeStruckOutAndHaveDocumentTemplate() {
+        check(STRUCK_OUT, APPOINTEE, strikeoutTemplate);
+    }
+
+    @Test
+    public void getStruckOutRepTemplateWhenRepStruckOutAndHaveDocumentTemplate() {
+        check(STRUCK_OUT, REPRESENTATIVE, strikeoutRepTemplate);
+    }
+
+    @Test
+    public void noTemplateWhenStruckOutAndDoNotHaveDocumentTemplate() {
+        String bundledLetterTemplate = bundledLetterTemplateUtil.getBundledLetterTemplate(STRUCK_OUT, sscsCaseDataWithoutDocument, APPELLANT);
+
+        assertThat(bundledLetterTemplate, is(nullValue()));
+    }
+
+    @Test
+    public void getDirectionTemplateWhenAppellantDirectionIssuedHaveDocumentTemplate() {
+        check(DIRECTION_ISSUED, APPELLANT, directionTemplate);
+    }
+
+    @Test
+    public void getDirectionTemplateWhenAppointeeDirectionIssuedHaveDocumentTemplate() {
+        check(DIRECTION_ISSUED, APPOINTEE, directionTemplate);
+    }
+
+    @Test
+    public void getDirectionTemplateWhenRepDirectionIssuedHaveDocumentTemplate() {
+        check(DIRECTION_ISSUED, REPRESENTATIVE, directionRepTemplate);
+    }
+
+    @Test
+    public void noTemplateWhenDirectionIssuedAndDoNotHaveDocumentTemplate() {
+        String bundledLetterTemplate = bundledLetterTemplateUtil.getBundledLetterTemplate(DIRECTION_ISSUED, sscsCaseDataWithoutDocument, APPELLANT);
+
+        assertThat(bundledLetterTemplate, is(nullValue()));
+    }
+
+    private void check(NotificationEventType notificationEventType, SubscriptionType subscriptionType, String expectedTemplate) {
+        String bundledLetterTemplate = bundledLetterTemplateUtil.getBundledLetterTemplate(notificationEventType, sscsCaseDataWithDocument, subscriptionType);
+        assertThat(bundledLetterTemplate, is(expectedTemplate));
+    }
+
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/SendNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/SendNotificationServiceTest.java
@@ -1,30 +1,27 @@
 package uk.gov.hmcts.reform.sscs.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static uk.gov.hmcts.reform.sscs.config.AppConstants.REP_SALUTATION;
-import static uk.gov.hmcts.reform.sscs.config.SubscriptionType.APPELLANT;
-import static uk.gov.hmcts.reform.sscs.config.SubscriptionType.APPOINTEE;
-import static uk.gov.hmcts.reform.sscs.config.SubscriptionType.REPRESENTATIVE;
+import static uk.gov.hmcts.reform.sscs.config.SubscriptionType.*;
 import static uk.gov.hmcts.reform.sscs.service.LetterUtils.getAddressToUseForLetter;
 import static uk.gov.hmcts.reform.sscs.service.NotificationValidService.BUNDLED_LETTER_EVENT_TYPES;
 import static uk.gov.hmcts.reform.sscs.service.NotificationValidService.FALLBACK_LETTER_SUBSCRIPTION_TYPES;
 import static uk.gov.hmcts.reform.sscs.service.SendNotificationService.getBundledLetterFileType;
 import static uk.gov.hmcts.reform.sscs.service.SendNotificationService.getRepSalutation;
 
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.config.AppealHearingType;
 import uk.gov.hmcts.reform.sscs.config.SubscriptionType;
@@ -126,15 +123,16 @@ public class SendNotificationServiceTest {
     @Mock
     private NotificationValidService notificationValidService;
 
+    @Mock
+    private BundledLetterTemplateUtil bundledLetterTemplateUtil;
+
     private SendNotificationService classUnderTest;
 
     @Before
     public void setup() {
         initMocks(this);
 
-        classUnderTest = new SendNotificationService(notificationSender, evidenceManagementService, pdfService, notificationHandler, notificationValidService);
-        ReflectionTestUtils.setField(classUnderTest, "strikeOutLetterTemplate", "/templates/strike_out_letter_template.html");
-        ReflectionTestUtils.setField(classUnderTest, "directionNoticeLetterTemplate", "/templates/direction_notice_letter_template.html");
+        classUnderTest = new SendNotificationService(notificationSender, evidenceManagementService, pdfService, notificationHandler, notificationValidService, bundledLetterTemplateUtil);
         classUnderTest.bundledLettersOn = true;
         classUnderTest.lettersOn = true;
     }
@@ -328,18 +326,6 @@ public class SendNotificationServiceTest {
     public void getRepSalutationWhenRepHasOrgAndName() {
         CcdNotificationWrapper wrapper = buildBaseWrapper(APPELLANT_WITH_ADDRESS, NotificationEventType.CASE_UPDATED, REP_ORG_WITH_NAME_AND_ADDRESS);
         assertEquals(REP_ORG_WITH_NAME_AND_ADDRESS.getName().getFullNameNoTitle(), getRepSalutation(wrapper.getNewSscsCaseData().getAppeal().getRep()));
-    }
-
-    @Test
-    @Parameters(method = "bundledLetterTemplates")
-    public void validBundledLetterTemplate(NotificationEventType eventType) {
-        assertNotNull(classUnderTest.getBundledLetterTemplate(eventType, buildBaseWrapper(APPELLANT_WITH_ADDRESS, eventType).getNewSscsCaseData()));
-    }
-
-    @Test
-    @Parameters(method = "nonBundledLetterTemplates")
-    public void invalidBundledLetterTemplate(NotificationEventType eventType) {
-        assertNull(classUnderTest.getBundledLetterTemplate(eventType, buildBaseWrapper(APPELLANT_WITH_ADDRESS, eventType).getNewSscsCaseData()));
     }
 
     @Test


### PR DESCRIPTION
When we send a bundled letter, either struck out or direction issued we
need to use a different template for the letter sent to the the
representative. These templates have been added to sscs-pdf-email-common
and need to be selected for use.

https://tools.hmcts.net/jira/browse/SSCS-5512

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
