### PR TITLE
SSCS-5806 Add TYA id to the COR register link

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
@@ -91,7 +91,8 @@ public class Personalisation<E extends NotificationWrapper> {
 
         personalisation.put(INFO_REQUEST_DETAIL, StringUtils.defaultIfBlank(getLatestInfoRequestDetail(ccdResponse), StringUtils.EMPTY));
 
-        subscriptionDetails(personalisation, subscriptionWithType.getSubscription(), benefit);
+        Subscription subscription = subscriptionWithType.getSubscription();
+        subscriptionDetails(personalisation, subscription, benefit);
 
         personalisation.put(FIRST_TIER_AGENCY_ACRONYM, DWP_ACRONYM);
         personalisation.put(FIRST_TIER_AGENCY_FULL_NAME, DWP_FUL_NAME);
@@ -119,7 +120,8 @@ public class Personalisation<E extends NotificationWrapper> {
         personalisation.put(ACCEPT_VIEW_BY_DATE_LITERAL, notificationDateConverterUtil.toEmailDate(today.plusDays(7)));
         personalisation.put(QUESTION_ROUND_EXPIRES_DATE_LITERAL, notificationDateConverterUtil.toEmailDate(today.plusDays(1)));
 
-        personalisation.put(ONLINE_HEARING_REGISTER_LINK_LITERAL, config.getOnlineHearingLink() + "/register");
+        final String tya = tya(subscription);
+        personalisation.put(ONLINE_HEARING_REGISTER_LINK_LITERAL, config.getOnlineHearingLink() + "/register?tya=" + tya);
         personalisation.put(ONLINE_HEARING_SIGN_IN_LINK_LITERAL, config.getOnlineHearingLink() + "/sign-in");
 
         personalisation.put(APPOINTEE_DESCRIPTION, getAppointeeDescription(subscriptionWithType.getSubscriptionType(), ccdResponse));

--- a/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
@@ -643,7 +643,7 @@ public class PersonalisationTest {
                 .build(), new SubscriptionWithType(subscriptions.getAppellantSubscription(), APPELLANT));
 
         assertEquals("http://link.com/onlineHearing?email=test%40email.com", result.get(ONLINE_HEARING_LINK_LITERAL));
-        assertEquals("http://link.com/register", result.get(ONLINE_HEARING_REGISTER_LINK_LITERAL));
+        assertEquals("http://link.com/register?tya=GLSCRR", result.get(ONLINE_HEARING_REGISTER_LINK_LITERAL));
         assertEquals("http://link.com/sign-in", result.get(ONLINE_HEARING_SIGN_IN_LINK_LITERAL));
     }
 


### PR DESCRIPTION
When we send an email to a user saying they have question to be answered
by the panel, we send them a link to register on COR. This will become
MYA and they will need a TYA number to be included in the url.

Format for new url
http://{domain}/register?tya=XXXXXXXXX

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
