### PR TITLE
SSCS-6316 - Store emails

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,8 +246,8 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-job-scheduler', version: '1.5.2'
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.0.0'
 
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '3.0.45'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.1.2'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '3.0.50-SSCS-6316-RC'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.1.3-SSCS-6316-1-RC'
 
     compile group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.14.2-RELEASE'
     compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.8.0'

--- a/build.gradle
+++ b/build.gradle
@@ -238,7 +238,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.0.0'
 
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '3.0.51-SSCS-6330-2-RC'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.1.3-SSCS-6316-2-RC'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.1.3-SSCS-6316-6-RC'
 
     compile group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.14.2-RELEASE'
     compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.8.0'

--- a/build.gradle
+++ b/build.gradle
@@ -226,6 +226,7 @@ dependencies {
     compile group: 'io.rest-assured', name: 'rest-assured', version: '3.3.0'
     compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
     compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
+    compile group: 'com.atlassian.commonmark', name: 'commonmark', version: '0.13.0'
 
     compile group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version:'0.0.4'
     compile group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version:'0.0.4'
@@ -236,8 +237,8 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-job-scheduler', version: '1.5.2'
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.0.0'
 
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '3.0.50-SSCS-6316-RC'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.1.3-SSCS-6316-1-RC'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '3.0.51-SSCS-6330-2-RC'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.1.3-SSCS-6316-2-RC'
 
     compile group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.14.2-RELEASE'
     compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.8.0'

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -157,7 +157,9 @@ module "track-your-appeal-notifications" {
 
     APPEAL_RECEIVED_LETTER_ON           = "${var.appeal_received_letter_on}"
 
-    DIRECTION_ISSUED_LETTER_ON           = "${var.direction_issued_letter_on}"
+    DIRECTION_ISSUED_LETTER_ON          = "${var.direction_issued_letter_on}"
+
+    SAVE_CORRESPONDENCE                 = "${var.save_correspondence}"
   }
 }
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -139,6 +139,11 @@ variable "direction_issued_letter_on" {
   default = false
 }
 
+variable "save_correspondence" {
+  type = "string"
+  default = true
+}
+
 variable "appinsights_instrumentation_key" {
   description = "Instrumentation key of the App Insights instance this webapp should use. Module will create own App Insights resource if this is not provided"
   default     = ""

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/service/NotificationServiceForSubscriptionUpdatedTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/service/NotificationServiceForSubscriptionUpdatedTest.java
@@ -195,8 +195,8 @@ public class NotificationServiceForSubscriptionUpdatedTest {
         SscsCaseDataWrapper wrapper = getSscsCaseDataWrapper(newSscsCaseData, oldSscsCaseData);
 
         notificationService.manageNotificationAndSubscription(new CcdNotificationWrapper(wrapper));
-        verify(notificationSender).sendEmail(eq(subscriptionUpdatedEmailId), eq(newSubscription.getEmail()), any(), any(), any());
-        verify(notificationSender).sendEmail(eq(getAppealReceivedEmailId(who)), eq(newSubscription.getEmail()), any(), any(), any());
+        verify(notificationSender).sendEmail(eq(subscriptionUpdatedEmailId), eq(newSubscription.getEmail()), any(), any(), any(), any());
+        verify(notificationSender).sendEmail(eq(getAppealReceivedEmailId(who)), eq(newSubscription.getEmail()), any(), any(), any(), any());
         verifyNoMoreInteractions(notificationSender);
     }
 
@@ -255,8 +255,8 @@ public class NotificationServiceForSubscriptionUpdatedTest {
         SscsCaseDataWrapper wrapper = getSscsCaseDataWrapper(newSscsCaseData, oldSscsCaseData);
 
         notificationService.manageNotificationAndSubscription(new CcdNotificationWrapper(wrapper));
-        verify(notificationSender).sendEmail(eq(subscriptionUpdatedEmailId), eq(newSubscription.getEmail()), any(), any(), any());
-        verify(notificationSender).sendEmail(eq(getAppealReceivedEmailId(appellant)), eq(newSubscription.getEmail()), any(), any(), any());
+        verify(notificationSender).sendEmail(eq(subscriptionUpdatedEmailId), eq(newSubscription.getEmail()), any(), any(), any(), any());
+        verify(notificationSender).sendEmail(eq(getAppealReceivedEmailId(appellant)), eq(newSubscription.getEmail()), any(), any(), any(), any());
         verify(notificationSender).sendSms(eq(subscriptionCreatedAppellantSmsId), eq(newSubscription.getMobile()), any(), any(), any(), any());
         verify(notificationSender).sendSms(eq(getAppealReceivedSmsId(appellant)), eq(newSubscription.getMobile()), any(), any(), any(), any());
 
@@ -273,8 +273,8 @@ public class NotificationServiceForSubscriptionUpdatedTest {
         SscsCaseDataWrapper wrapper = getSscsCaseDataWrapper(newSscsCaseData, oldSscsCaseData);
 
         notificationService.manageNotificationAndSubscription(new CcdNotificationWrapper(wrapper));
-        verify(notificationSender).sendEmail(eq(subscriptionUpdatedEmailId), eq(newSubscription.getEmail()), any(), any(), any());
-        verify(notificationSender).sendEmail(eq(getAppealReceivedEmailId(appointee)), eq(newSubscription.getEmail()), any(), any(), any());
+        verify(notificationSender).sendEmail(eq(subscriptionUpdatedEmailId), eq(newSubscription.getEmail()), any(), any(), any(), any());
+        verify(notificationSender).sendEmail(eq(getAppealReceivedEmailId(appointee)), eq(newSubscription.getEmail()), any(), any(), any(), any());
         verify(notificationSender).sendSms(eq(subscriptionCreatedAppointeeSmsId), eq(newSubscription.getMobile()), any(), any(), any(), any());
         verify(notificationSender).sendSms(eq(getAppealReceivedSmsId(appointee)), eq(newSubscription.getMobile()), any(), any(), any(), any());
 
@@ -291,8 +291,8 @@ public class NotificationServiceForSubscriptionUpdatedTest {
         SscsCaseDataWrapper wrapper = getSscsCaseDataWrapper(newSscsCaseData, oldSscsCaseData);
 
         notificationService.manageNotificationAndSubscription(new CcdNotificationWrapper(wrapper));
-        verify(notificationSender).sendEmail(eq(subscriptionUpdatedEmailId), eq(newSubscription.getEmail()), any(), any(), any());
-        verify(notificationSender).sendEmail(eq(getAppealReceivedEmailId(representative)), eq(newSubscription.getEmail()), any(), any(), any());
+        verify(notificationSender).sendEmail(eq(subscriptionUpdatedEmailId), eq(newSubscription.getEmail()), any(), any(), any(), any());
+        verify(notificationSender).sendEmail(eq(getAppealReceivedEmailId(representative)), eq(newSubscription.getEmail()), any(), any(), any(), any());
         verify(notificationSender).sendSms(eq(subscriptionCreatedRepresentativeSmsId), eq(newSubscription.getMobile()), any(), any(), any(), any());
         verify(notificationSender).sendSms(eq(getAppealReceivedSmsId(representative)), eq(newSubscription.getMobile()), any(), any(), any(), any());
 
@@ -311,8 +311,8 @@ public class NotificationServiceForSubscriptionUpdatedTest {
 
         notificationService.manageNotificationAndSubscription(new CcdNotificationWrapper(wrapper));
 
-        verify(notificationSender).sendEmail(eq(subscriptionUpdatedEmailId), eq(subscription.getEmail()), any(), any(), any());
-        verify(notificationSender).sendEmail(eq(subscriptionOldEmailId), eq(oldSubscription.getEmail()), any(), any(), any());
+        verify(notificationSender).sendEmail(eq(subscriptionUpdatedEmailId), eq(subscription.getEmail()), any(), any(), any(), any());
+        verify(notificationSender).sendEmail(eq(subscriptionOldEmailId), eq(oldSubscription.getEmail()), any(), any(), any(), any());
 
         verifyNoMoreInteractions(notificationSender);
     }
@@ -384,8 +384,8 @@ public class NotificationServiceForSubscriptionUpdatedTest {
 
         notificationService.manageNotificationAndSubscription(new CcdNotificationWrapper(wrapper));
 
-        verify(notificationSender).sendEmail(eq(subscriptionUpdatedEmailId), eq(subscription.getEmail()), any(), any(), any());
-        verify(notificationSender).sendEmail(eq(subscriptionOldEmailId), eq(oldSubscription.getEmail()), any(), any(), any());
+        verify(notificationSender).sendEmail(eq(subscriptionUpdatedEmailId), eq(subscription.getEmail()), any(), any(), any(), any());
+        verify(notificationSender).sendEmail(eq(subscriptionOldEmailId), eq(oldSubscription.getEmail()), any(), any(), any(), any());
         verify(notificationSender).sendSms(eq(subscriptionCreatedAppellantSmsId), eq(subscription.getMobile()), any(), any(), any(), any());
         verify(notificationSender).sendSms(eq(subscriptionOldSmsId), eq(oldSubscription.getMobile()), any(), any(), any(), any());
 
@@ -404,8 +404,8 @@ public class NotificationServiceForSubscriptionUpdatedTest {
 
         notificationService.manageNotificationAndSubscription(new CcdNotificationWrapper(wrapper));
 
-        verify(notificationSender).sendEmail(eq(subscriptionUpdatedEmailId), eq(subscription.getEmail()), any(), any(), any());
-        verify(notificationSender).sendEmail(eq(subscriptionOldEmailId), eq(oldSubscription.getEmail()), any(), any(), any());
+        verify(notificationSender).sendEmail(eq(subscriptionUpdatedEmailId), eq(subscription.getEmail()), any(), any(), any(), any());
+        verify(notificationSender).sendEmail(eq(subscriptionOldEmailId), eq(oldSubscription.getEmail()), any(), any(), any(), any());
         verify(notificationSender).sendSms(eq(subscriptionCreatedAppointeeSmsId), eq(subscription.getMobile()), any(), any(), any(), any());
         verify(notificationSender).sendSms(eq(subscriptionOldSmsId), eq(oldSubscription.getMobile()), any(), any(), any(), any());
 
@@ -424,8 +424,8 @@ public class NotificationServiceForSubscriptionUpdatedTest {
 
         notificationService.manageNotificationAndSubscription(new CcdNotificationWrapper(wrapper));
 
-        verify(notificationSender).sendEmail(eq(subscriptionUpdatedEmailId), eq(subscription.getEmail()), any(), any(), any());
-        verify(notificationSender).sendEmail(eq(subscriptionOldEmailId), eq(oldSubscription.getEmail()), any(), any(), any());
+        verify(notificationSender).sendEmail(eq(subscriptionUpdatedEmailId), eq(subscription.getEmail()), any(), any(), any(), any());
+        verify(notificationSender).sendEmail(eq(subscriptionOldEmailId), eq(oldSubscription.getEmail()), any(), any(), any(), any());
         verify(notificationSender).sendSms(eq(subscriptionCreatedRepresentativeSmsId), eq(subscription.getMobile()), any(), any(), any(), any());
         verify(notificationSender).sendSms(eq(subscriptionOldSmsId), eq(oldSubscription.getMobile()), any(), any(), any(), any());
 

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/CohNotificationsIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/CohNotificationsIt.java
@@ -128,9 +128,13 @@ public class CohNotificationsIt {
 
     String json;
 
+    @Mock
+    private MarkdownTransformationService markdownTransformationService;
+
     @Before
     public void setup() throws Exception {
-        NotificationSender sender = new NotificationSender(notificationClient, null, notificationBlacklist, ccdPdfService);
+        Boolean saveCorrespondence = false;
+        NotificationSender sender = new NotificationSender(notificationClient, null, notificationBlacklist, ccdPdfService, markdownTransformationService, saveCorrespondence);
 
         SendNotificationService sendNotificationService = new SendNotificationService(sender, evidenceManagementService, sscsGeneratePdfService, notificationHandler, notificationValidService, bundledLetterTemplateUtil, pdfLetterService);
         ReflectionTestUtils.setField(sendNotificationService, "bundledLettersOn", true);

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/CohNotificationsIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/CohNotificationsIt.java
@@ -123,11 +123,14 @@ public class CohNotificationsIt {
     @Mock
     private PdfLetterService pdfLetterService;
 
+    @Mock
+    private CcdPdfService ccdPdfService;
+
     String json;
 
     @Before
     public void setup() throws Exception {
-        NotificationSender sender = new NotificationSender(notificationClient, null, notificationBlacklist);
+        NotificationSender sender = new NotificationSender(notificationClient, null, notificationBlacklist, ccdPdfService);
 
         SendNotificationService sendNotificationService = new SendNotificationService(sender, evidenceManagementService, sscsGeneratePdfService, notificationHandler, notificationValidService, bundledLetterTemplateUtil, pdfLetterService);
         ReflectionTestUtils.setField(sendNotificationService, "bundledLettersOn", true);

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/NotificationsIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/NotificationsIt.java
@@ -128,12 +128,15 @@ public class NotificationsIt {
     @Value("${notification.subscriptionUpdated.emailId}")
     private String subscriptionUpdatedEmailId;
 
+    @Mock
+    private CcdPdfService ccdPdfService;
+
     @Value("${notification.subscriptionCreated.appellant.smsId}")
     private String subscriptionCreatedSmsId;
 
     @Before
     public void setup() throws Exception {
-        NotificationSender sender = new NotificationSender(notificationClient, null, notificationBlacklist);
+        NotificationSender sender = new NotificationSender(notificationClient, null, notificationBlacklist, ccdPdfService);
 
         SendNotificationService sendNotificationService = new SendNotificationService(sender, evidenceManagementService, sscsGeneratePdfService, notificationHandler, notificationValidService, bundledLetterTemplateUtil, pdfLetterService);
 

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/NotificationsIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/NotificationsIt.java
@@ -134,9 +134,14 @@ public class NotificationsIt {
     @Value("${notification.subscriptionCreated.appellant.smsId}")
     private String subscriptionCreatedSmsId;
 
+    private final Boolean saveCorrespondence = false;
+
+    @Mock
+    private MarkdownTransformationService markdownTransformationService;
+
     @Before
     public void setup() throws Exception {
-        NotificationSender sender = new NotificationSender(notificationClient, null, notificationBlacklist, ccdPdfService);
+        NotificationSender sender = new NotificationSender(notificationClient, null, notificationBlacklist, ccdPdfService, markdownTransformationService, saveCorrespondence);
 
         SendNotificationService sendNotificationService = new SendNotificationService(sender, evidenceManagementService, sscsGeneratePdfService, notificationHandler, notificationValidService, bundledLetterTemplateUtil, pdfLetterService);
 

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/OutOfHoursIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/OutOfHoursIt.java
@@ -131,13 +131,16 @@ public class OutOfHoursIt {
     @Mock
     private SscsGeneratePdfService sscsGeneratePdfService;
 
+    @Mock
+    private CcdPdfService ccdPdfService;
+
     @Autowired
     @Qualifier("scheduler")
     private Scheduler quartzScheduler;
 
     @Before
     public void setup() throws Exception {
-        NotificationSender sender = new NotificationSender(notificationClient, null, notificationBlacklist);
+        NotificationSender sender = new NotificationSender(notificationClient, null, notificationBlacklist, ccdPdfService);
 
         SendNotificationService sendNotificationService = new SendNotificationService(sender, evidenceManagementService, sscsGeneratePdfService, notificationHandler, notificationValidService, bundledLetterTemplateUtil, pdfLetterService);
         ReflectionTestUtils.setField(sendNotificationService, "bundledLettersOn", true);

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/OutOfHoursIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/OutOfHoursIt.java
@@ -138,9 +138,12 @@ public class OutOfHoursIt {
     @Qualifier("scheduler")
     private Scheduler quartzScheduler;
 
+    @Mock
+    private MarkdownTransformationService markdownTransformationService;
+
     @Before
     public void setup() throws Exception {
-        NotificationSender sender = new NotificationSender(notificationClient, null, notificationBlacklist, ccdPdfService);
+        NotificationSender sender = new NotificationSender(notificationClient, null, notificationBlacklist, ccdPdfService, markdownTransformationService, false);
 
         SendNotificationService sendNotificationService = new SendNotificationService(sender, evidenceManagementService, sscsGeneratePdfService, notificationHandler, notificationValidService, bundledLetterTemplateUtil, pdfLetterService);
         ReflectionTestUtils.setField(sendNotificationService, "bundledLettersOn", true);

--- a/src/main/java/uk/gov/hmcts/reform/sscs/config/PdfServiceConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/config/PdfServiceConfiguration.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
-import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.pdf.service.client.PDFServiceClient;
 
 @Configuration
@@ -19,12 +18,11 @@ public class PdfServiceConfiguration {
     @Bean
     public PDFServiceClient pdfServiceClient(
         RestTemplate restTemplate,
-        ObjectMapper objectMapper,
-        AuthTokenGenerator authTokenGenerator
+        ObjectMapper objectMapper
     ) {
         return PDFServiceClient.builder()
             .restOperations(restTemplate)
             .objectMapper(objectMapper)
-            .build(authTokenGenerator::generate, create(pdfApiUrl));
+            .build(create(pdfApiUrl));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/MarkdownTransformationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/MarkdownTransformationService.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 public class MarkdownTransformationService {
 
     private final Parser parser = Parser.builder().build();
-    private final HtmlRenderer renderer = HtmlRenderer.builder().build();
+    private final HtmlRenderer renderer = HtmlRenderer.builder().softbreak("<br/>").escapeHtml(true).build();
 
     public String toHtml(String markdown) {
         Node document = parser.parse(markdown);

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/MarkdownTransformationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/MarkdownTransformationService.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MarkdownTransformationService {
+
+    private final Parser parser = Parser.builder().build();
+    private final HtmlRenderer renderer = HtmlRenderer.builder().build();
+
+    public String toHtml(String markdown) {
+        Node document = parser.parse(markdown);
+
+        return renderer.render(document);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/NotificationSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/NotificationSender.java
@@ -70,7 +70,7 @@ public class NotificationSender {
                             .subject(sendEmailResponse.getSubject())
                             .from(sendEmailResponse.getFromEmail().orElse(""))
                             .to(emailAddress)
-                            .eventType(notificationEventType.name())
+                            .eventType(notificationEventType.getId())
                             .correspondenceType(CorrespondenceType.Email)
                             .sentOn(LocalDateTime.now().format(DATE_TIME_FORMATTER))
                             .build()

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/SendNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/SendNotificationService.java
@@ -136,7 +136,7 @@ public class SendNotificationService {
                             notification.getEmail(),
                             notification.getPlaceholders(),
                             notification.getReference(),
-                            wrapper.getCaseId()
+                            wrapper.getNewSscsCaseData()
                     );
             notificationHandler.sendNotification(wrapper, notification.getEmailTemplate(), "Email", sendNotification);
         }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/SendNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/SendNotificationService.java
@@ -136,7 +136,9 @@ public class SendNotificationService {
                             notification.getEmail(),
                             notification.getPlaceholders(),
                             notification.getReference(),
+                            wrapper.getNotificationType(),
                             wrapper.getNewSscsCaseData()
+
                     );
             notificationHandler.sendNotification(wrapper, notification.getEmailTemplate(), "Email", sendNotification);
         }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -355,7 +355,7 @@ feign:
         decode404: true
 
 # Document store
-document_management.url: ${DOCUMENT_MANAGEMENT_URL:http://dm-store:4506}
+document_management.url: ${DOCUMENT_MANAGEMENT_URL:http://dm-store:5005}
 
 appeal.email.host: ${EMAIL_SERVER_HOST:localhost}
 appeal.email.port: ${EMAIL_SERVER_PORT:1025}
@@ -390,6 +390,7 @@ feature.docmosis_letters_on: ${DOCMOSIS_LETTERS_ON:true}
 feature.interloc_letters_on: ${INTERLOC_LETTERS_ON:true}
 feature.docmosis_leters.appealReceived_on: ${APPEAL_RECEIVED_LETTER_ON:true}
 feature.docmosis_leters.directionIssued_on: ${DIRECTION_ISSUED_LETTER_ON:true}
+feature.save_correspondence: ${SAVE_CORRESPONDENCE:false}
 
 pdf-service:
   uri: ${PDF_SERVICE_BASE_URL:https://docmosis-development.platform.hmcts.net/rs/render}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/MarkdownTransformationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/MarkdownTransformationServiceTest.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class MarkdownTransformationServiceTest {
+
+    private MarkdownTransformationService markdownTransformationService = new MarkdownTransformationService();
+
+    @Test
+    public void toHtml() {
+        String html = markdownTransformationService.toHtml("test");
+
+        assertEquals("<p>test</p>\n", html);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/NotificationSenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/NotificationSenderTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Address;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.config.NotificationBlacklist;
+import uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType;
 import uk.gov.service.notify.*;
 
 public class NotificationSenderTest {
@@ -45,6 +46,12 @@ public class NotificationSenderTest {
     @Mock
     private SendLetterResponse sendLetterResponse;
 
+
+    private final Boolean saveCorrespondence = false;
+
+    @Mock
+    private MarkdownTransformationService markdownTransformationService;
+
     @Before
     public void setUp() {
         initMocks(this);
@@ -56,7 +63,7 @@ public class NotificationSenderTest {
         personalisation = Collections.emptyMap();
         reference = "reference";
 
-        notificationSender = new NotificationSender(notificationClient, testNotificationClient, blacklist, ccdPdfService);
+        notificationSender = new NotificationSender(notificationClient, testNotificationClient, blacklist, ccdPdfService, markdownTransformationService, saveCorrespondence);
     }
 
     @Test
@@ -66,7 +73,7 @@ public class NotificationSenderTest {
                 .thenReturn(sendEmailResponse);
         when(sendEmailResponse.getNotificationId()).thenReturn(UUID.randomUUID());
 
-        notificationSender.sendEmail(templateId, emailAddress, personalisation, reference, SSCS_CASE_DATA);
+        notificationSender.sendEmail(templateId, emailAddress, personalisation, reference, NotificationEventType.APPEAL_RECEIVED_NOTIFICATION, SSCS_CASE_DATA);
 
         verifyZeroInteractions(notificationClient);
         verify(testNotificationClient).sendEmail(templateId, emailAddress, personalisation, reference);
@@ -79,7 +86,7 @@ public class NotificationSenderTest {
                 .thenReturn(sendEmailResponse);
         when(sendEmailResponse.getNotificationId()).thenReturn(UUID.randomUUID());
 
-        notificationSender.sendEmail(templateId, emailAddress, personalisation, reference, SSCS_CASE_DATA);
+        notificationSender.sendEmail(templateId, emailAddress, personalisation, reference, NotificationEventType.APPEAL_RECEIVED_NOTIFICATION, SSCS_CASE_DATA);
 
         verifyZeroInteractions(testNotificationClient);
         verify(notificationClient).sendEmail(templateId, emailAddress, personalisation, reference);
@@ -93,7 +100,7 @@ public class NotificationSenderTest {
                 .thenReturn(sendEmailResponse);
         when(sendEmailResponse.getNotificationId()).thenReturn(UUID.randomUUID());
 
-        notificationSender.sendEmail(templateId, emailAddress, personalisation, reference, SSCS_CASE_DATA);
+        notificationSender.sendEmail(templateId, emailAddress, personalisation, reference, NotificationEventType.APPEAL_RECEIVED_NOTIFICATION, SSCS_CASE_DATA);
 
         verifyZeroInteractions(notificationClient);
         verify(testNotificationClient).sendEmail(templateId, emailAddress, personalisation, reference);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/NotificationSenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/NotificationSenderTest.java
@@ -14,11 +14,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Address;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.config.NotificationBlacklist;
 import uk.gov.service.notify.*;
 
 public class NotificationSenderTest {
     public static final String CCD_CASE_ID = "78980909090099";
+    public static final SscsCaseData SSCS_CASE_DATA = SscsCaseData.builder().build();
     public static final String SMS_SENDER = "sms-sender";
     private NotificationClient notificationClient;
     private NotificationClient testNotificationClient;
@@ -38,6 +40,9 @@ public class NotificationSenderTest {
     private LetterResponse letterResponse;
 
     @Mock
+    private CcdPdfService ccdPdfService;
+
+    @Mock
     private SendLetterResponse sendLetterResponse;
 
     @Before
@@ -51,7 +56,7 @@ public class NotificationSenderTest {
         personalisation = Collections.emptyMap();
         reference = "reference";
 
-        notificationSender = new NotificationSender(notificationClient, testNotificationClient, blacklist);
+        notificationSender = new NotificationSender(notificationClient, testNotificationClient, blacklist, ccdPdfService);
     }
 
     @Test
@@ -61,7 +66,7 @@ public class NotificationSenderTest {
                 .thenReturn(sendEmailResponse);
         when(sendEmailResponse.getNotificationId()).thenReturn(UUID.randomUUID());
 
-        notificationSender.sendEmail(templateId, emailAddress, personalisation, reference, CCD_CASE_ID);
+        notificationSender.sendEmail(templateId, emailAddress, personalisation, reference, SSCS_CASE_DATA);
 
         verifyZeroInteractions(notificationClient);
         verify(testNotificationClient).sendEmail(templateId, emailAddress, personalisation, reference);
@@ -74,7 +79,7 @@ public class NotificationSenderTest {
                 .thenReturn(sendEmailResponse);
         when(sendEmailResponse.getNotificationId()).thenReturn(UUID.randomUUID());
 
-        notificationSender.sendEmail(templateId, emailAddress, personalisation, reference, CCD_CASE_ID);
+        notificationSender.sendEmail(templateId, emailAddress, personalisation, reference, SSCS_CASE_DATA);
 
         verifyZeroInteractions(testNotificationClient);
         verify(notificationClient).sendEmail(templateId, emailAddress, personalisation, reference);
@@ -88,7 +93,7 @@ public class NotificationSenderTest {
                 .thenReturn(sendEmailResponse);
         when(sendEmailResponse.getNotificationId()).thenReturn(UUID.randomUUID());
 
-        notificationSender.sendEmail(templateId, emailAddress, personalisation, reference, CCD_CASE_ID);
+        notificationSender.sendEmail(templateId, emailAddress, personalisation, reference, SSCS_CASE_DATA);
 
         verifyZeroInteractions(notificationClient);
         verify(testNotificationClient).sendEmail(templateId, emailAddress, personalisation, reference);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/NotificationServiceTest.java
@@ -1358,7 +1358,7 @@ public class NotificationServiceTest {
         when(factory.create(ccdNotificationWrapper, getSubscriptionWithType(ccdNotificationWrapper))).thenReturn(notification);
         notificationService.manageNotificationAndSubscription(ccdNotificationWrapper);
 
-        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), ccdNotificationWrapper.getNewSscsCaseData());
+        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), sscsCaseDataWrapper.getNotificationEventType(), ccdNotificationWrapper.getNewSscsCaseData());
     }
 
     @Test
@@ -1376,7 +1376,7 @@ public class NotificationServiceTest {
         when(factory.create(ccdNotificationWrapper, getSubscriptionWithType(ccdNotificationWrapper))).thenReturn(notification);
         notificationService.manageNotificationAndSubscription(ccdNotificationWrapper);
 
-        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), ccdNotificationWrapper.getNewSscsCaseData());
+        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), sscsCaseDataWrapper.getNotificationEventType(), ccdNotificationWrapper.getNewSscsCaseData());
     }
 
     @Test
@@ -1404,7 +1404,7 @@ public class NotificationServiceTest {
         notificationService.manageNotificationAndSubscription(ccdNotificationWrapper);
 
         verify(notificationSender, never()).sendSms(notification.getSmsTemplate(), notification.getMobile(), notification.getPlaceholders(), notification.getReference(), notification.getSmsSenderTemplate(), ccdNotificationWrapper.getCaseId());
-        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), ccdNotificationWrapper.getNewSscsCaseData());
+        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), sscsCaseDataWrapper.getNotificationEventType(), ccdNotificationWrapper.getNewSscsCaseData());
     }
 
     @Test
@@ -1429,7 +1429,7 @@ public class NotificationServiceTest {
 
         notificationService.manageNotificationAndSubscription(ccdNotificationWrapper);
 
-        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), ccdNotificationWrapper.getNewSscsCaseData());
+        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), sscsCaseDataWrapper.getNotificationEventType(), ccdNotificationWrapper.getNewSscsCaseData());
     }
 
     @Test
@@ -1440,7 +1440,7 @@ public class NotificationServiceTest {
 
         notificationService.manageNotificationAndSubscription(ccdNotificationWrapper);
 
-        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), ccdNotificationWrapper.getNewSscsCaseData());
+        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), sscsCaseDataWrapper.getNotificationEventType(),  ccdNotificationWrapper.getNewSscsCaseData());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/NotificationServiceTest.java
@@ -1358,7 +1358,7 @@ public class NotificationServiceTest {
         when(factory.create(ccdNotificationWrapper, getSubscriptionWithType(ccdNotificationWrapper))).thenReturn(notification);
         notificationService.manageNotificationAndSubscription(ccdNotificationWrapper);
 
-        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), ccdNotificationWrapper.getCaseId());
+        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), ccdNotificationWrapper.getNewSscsCaseData());
     }
 
     @Test
@@ -1376,7 +1376,7 @@ public class NotificationServiceTest {
         when(factory.create(ccdNotificationWrapper, getSubscriptionWithType(ccdNotificationWrapper))).thenReturn(notification);
         notificationService.manageNotificationAndSubscription(ccdNotificationWrapper);
 
-        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), ccdNotificationWrapper.getCaseId());
+        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), ccdNotificationWrapper.getNewSscsCaseData());
     }
 
     @Test
@@ -1404,7 +1404,7 @@ public class NotificationServiceTest {
         notificationService.manageNotificationAndSubscription(ccdNotificationWrapper);
 
         verify(notificationSender, never()).sendSms(notification.getSmsTemplate(), notification.getMobile(), notification.getPlaceholders(), notification.getReference(), notification.getSmsSenderTemplate(), ccdNotificationWrapper.getCaseId());
-        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), ccdNotificationWrapper.getCaseId());
+        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), ccdNotificationWrapper.getNewSscsCaseData());
     }
 
     @Test
@@ -1429,7 +1429,7 @@ public class NotificationServiceTest {
 
         notificationService.manageNotificationAndSubscription(ccdNotificationWrapper);
 
-        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), ccdNotificationWrapper.getCaseId());
+        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), ccdNotificationWrapper.getNewSscsCaseData());
     }
 
     @Test
@@ -1440,7 +1440,7 @@ public class NotificationServiceTest {
 
         notificationService.manageNotificationAndSubscription(ccdNotificationWrapper);
 
-        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), ccdNotificationWrapper.getCaseId());
+        verify(notificationSender, never()).sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference(), ccdNotificationWrapper.getNewSscsCaseData());
     }
 
     @Test


### PR DESCRIPTION
Store all Gov.Notify emails in CCD Doc Store
Jira: https://tools.hmcts.net/jira/browse/SSCS-6316

A/C: Given an email is has been sent to an appellant
When the success message has been received from the email
Then log the date the email was sent
And the recipient email address that it was sent to
And the type of notification
And upload a PDF of the notification to Doc store
And add a link to the PDF to the case