### PR TITLE
SSCS-7953 - Directions - Appeal to Proceed for Joint Party

### DIFF
--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/config/NotificationConfigTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/config/NotificationConfigTest.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import junitparams.converters.Nullable;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -117,16 +118,16 @@ public class NotificationConfigTest {
 
     @Test
     @Parameters({
-            "APPEAL_TO_PROCEED, TB-SCS-GNO-ENG-00551.docx, TB-SCS-GNO-ENG-00551.docx",
-            "PROVIDE_INFORMATION, TB-SCS-GNO-ENG-00067.docx, TB-SCS-GNO-ENG-00089.docx",
-            "GRANT_EXTENSION, TB-SCS-GNO-ENG-00556.docx, TB-SCS-GNO-ENG-00556.docx",
-            "REFUSE_EXTENSION, TB-SCS-GNO-ENG-00557.docx, TB-SCS-GNO-ENG-00557.docx",
-            "APPEAL_TO_PROCEED, TB-SCS-GNO-WEL-00468.docx, TB-SCS-GNO-WEL-00472.docx",
-            "PROVIDE_INFORMATION, TB-SCS-GNO-WEL-00468.docx, TB-SCS-GNO-WEL-00472.docx",
-            "GRANT_EXTENSION, TB-SCS-GNO-WEL-00468.docx, TB-SCS-GNO-WEL-00472.docx",
-            "REFUSE_EXTENSION, TB-SCS-GNO-WEL-00468.docx, TB-SCS-GNO-WEL-00472.docx"
+            "APPEAL_TO_PROCEED, TB-SCS-GNO-ENG-00551.docx, TB-SCS-GNO-ENG-00551.docx, TB-SCS-GNO-ENG-00551.docx",
+            "PROVIDE_INFORMATION, TB-SCS-GNO-ENG-00067.docx, TB-SCS-GNO-ENG-00089.docx, null",
+            "GRANT_EXTENSION, TB-SCS-GNO-ENG-00556.docx, TB-SCS-GNO-ENG-00556.docx, null",
+            "REFUSE_EXTENSION, TB-SCS-GNO-ENG-00557.docx, TB-SCS-GNO-ENG-00557.docx, null",
+            "APPEAL_TO_PROCEED, TB-SCS-GNO-WEL-00468.docx, TB-SCS-GNO-WEL-00472.docx, null",
+            "PROVIDE_INFORMATION, TB-SCS-GNO-WEL-00468.docx, TB-SCS-GNO-WEL-00472.docx, null",
+            "GRANT_EXTENSION, TB-SCS-GNO-WEL-00468.docx, TB-SCS-GNO-WEL-00472.docx, null",
+            "REFUSE_EXTENSION, TB-SCS-GNO-WEL-00468.docx, TB-SCS-GNO-WEL-00472.docx, null"
     })
-    public void shouldGiveCorrectDocmosisIdForDirectionIssued(DirectionType directionType, String configAppellantOrAppointee, String configRep) {
+    public void shouldGiveCorrectDocmosisIdForDirectionIssued(DirectionType directionType, String configAppellantOrAppointee, String configRep, @Nullable String configJointParty) {
         NotificationWrapper wrapper = new CcdNotificationWrapper(SscsCaseDataWrapper.builder()
                 .newSscsCaseData(SscsCaseData.builder()
                         .languagePreferenceWelsh(configAppellantOrAppointee.contains("-WEL-") ? "Yes" : "No")
@@ -149,6 +150,8 @@ public class NotificationConfigTest {
         assertEquals(configAppellantOrAppointee, templateAppointee.getDocmosisTemplateId());
         Template templateRep = personalisation.getTemplate(wrapper, PIP, REPRESENTATIVE);
         assertEquals(configRep, templateRep.getDocmosisTemplateId());
+        Template templateJointParty = personalisation.getTemplate(wrapper, PIP, JOINT_PARTY);
+        assertEquals(configJointParty, templateJointParty.getDocmosisTemplateId());
     }
 
     @SuppressWarnings({"Indentation", "unused"})

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/JointPartyFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/JointPartyFunctionalTest.java
@@ -146,7 +146,7 @@ public class JointPartyFunctionalTest extends AbstractFunctionalTest {
             new Object[]{HEARING_REMINDER_NOTIFICATION, NO_HEARING_TYPE, expectedNumberOfLettersIsZero, isDocmosisLetterFalse},
             new Object[]{EVIDENCE_RECEIVED_NOTIFICATION, ORAL, expectedNumberOfLettersIsZero, isDocmosisLetterFalse},
             new Object[]{EVIDENCE_REMINDER_NOTIFICATION, PAPER, expectedNumberOfLettersIsZero, isDocmosisLetterFalse},
-            new Object[]{APPEAL_WITHDRAWN_NOTIFICATION, NO_HEARING_TYPE, expectedNumberOfLettersIsTwo, isDocmosisLetterFalse}
+            new Object[]{APPEAL_WITHDRAWN_NOTIFICATION, NO_HEARING_TYPE, expectedNumberOfLettersIsTwo, isDocmosisLetterFalse},
             new Object[]{DIRECTION_ISSUED, NO_HEARING_TYPE, expectedNumberOfLettersIsTwo, isDocmosisLetterTrue}
         };
     }

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/JointPartyFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/JointPartyFunctionalTest.java
@@ -71,7 +71,8 @@ public class JointPartyFunctionalTest extends AbstractFunctionalTest {
     @Test
     @Parameters(method = "eventTypeAndSubscriptions")
     public void givenEventAndJointPartySubscription_shouldSendNotificationToJointParty(
-            NotificationEventType notificationEventType, @Nullable String hearingType, int expectedNumberOfLetters)
+            NotificationEventType notificationEventType, @Nullable String hearingType,
+            int expectedNumberOfLetters, boolean isDocmosisLetter)
             throws Exception {
         //Given
         final String jointPartyEmailId = getFieldValue(hearingType, notificationEventType, "JointPartyEmailId");
@@ -101,11 +102,15 @@ public class JointPartyFunctionalTest extends AbstractFunctionalTest {
         if (expectedNumberOfLetters > 0) {
             List<Notification> notificationLetters = fetchLetters();
             assertEquals(expectedNumberOfLetters, notificationLetters.size());
-            Optional<Notification> notificationOptional =
-                    notificationLetters.stream().filter(notification ->
-                            notification.getLine1().map(f -> f.contains(jointPartyName)).orElse(false)).findFirst();
-            assertTrue(notificationOptional.isPresent());
-            assertTrue(notificationOptional.get().getBody().contains("Dear " + jointPartyName));
+            if (!isDocmosisLetter) {
+                Optional<Notification> notificationOptional =
+                        notificationLetters.stream().filter(notification ->
+                                notification.getLine1().map(f -> f.contains(jointPartyName)).orElse(false)).findFirst();
+                assertTrue(notificationOptional.isPresent());
+                assertTrue(notificationOptional.get().getBody().contains("Dear " + jointPartyName));
+            } else {
+                notificationLetters.forEach(n -> assertEquals("Pre-compiled PDF", n.getSubject().orElse("Unknown Subject")));
+            }
         }
     }
 
@@ -128,18 +133,21 @@ public class JointPartyFunctionalTest extends AbstractFunctionalTest {
     private Object[] eventTypeAndSubscriptions() {
         final int expectedNumberOfLettersIsTwo = 2;
         final int expectedNumberOfLettersIsZero = 0;
+        final boolean isDocmosisLetterTrue = true;
+        final boolean isDocmosisLetterFalse = false;
         return new Object[]{
-            new Object[]{APPEAL_LAPSED_NOTIFICATION, NO_HEARING_TYPE, expectedNumberOfLettersIsTwo},
-            new Object[]{APPEAL_DORMANT_NOTIFICATION, ORAL, expectedNumberOfLettersIsZero},
-            new Object[]{APPEAL_DORMANT_NOTIFICATION, PAPER, expectedNumberOfLettersIsZero},
-            new Object[]{ADJOURNED_NOTIFICATION, NO_HEARING_TYPE, expectedNumberOfLettersIsZero},
-            new Object[]{POSTPONEMENT_NOTIFICATION, NO_HEARING_TYPE, expectedNumberOfLettersIsZero},
-            new Object[]{EVIDENCE_REMINDER_NOTIFICATION, ORAL, expectedNumberOfLettersIsZero},
-            new Object[]{HEARING_BOOKED_NOTIFICATION, NO_HEARING_TYPE, expectedNumberOfLettersIsZero},
-            new Object[]{HEARING_REMINDER_NOTIFICATION, NO_HEARING_TYPE, expectedNumberOfLettersIsZero},
-            new Object[]{EVIDENCE_RECEIVED_NOTIFICATION, ORAL, expectedNumberOfLettersIsZero},
-            new Object[]{EVIDENCE_REMINDER_NOTIFICATION, PAPER, expectedNumberOfLettersIsZero},
-            new Object[]{APPEAL_WITHDRAWN_NOTIFICATION, NO_HEARING_TYPE, expectedNumberOfLettersIsTwo}
+            new Object[]{APPEAL_LAPSED_NOTIFICATION, NO_HEARING_TYPE, expectedNumberOfLettersIsTwo, isDocmosisLetterFalse},
+            new Object[]{APPEAL_DORMANT_NOTIFICATION, ORAL, expectedNumberOfLettersIsZero, isDocmosisLetterFalse},
+            new Object[]{APPEAL_DORMANT_NOTIFICATION, PAPER, expectedNumberOfLettersIsZero, isDocmosisLetterFalse},
+            new Object[]{ADJOURNED_NOTIFICATION, NO_HEARING_TYPE, expectedNumberOfLettersIsZero, isDocmosisLetterFalse},
+            new Object[]{POSTPONEMENT_NOTIFICATION, NO_HEARING_TYPE, expectedNumberOfLettersIsZero, isDocmosisLetterFalse},
+            new Object[]{EVIDENCE_REMINDER_NOTIFICATION, ORAL, expectedNumberOfLettersIsZero, isDocmosisLetterFalse},
+            new Object[]{HEARING_BOOKED_NOTIFICATION, NO_HEARING_TYPE, expectedNumberOfLettersIsZero, isDocmosisLetterFalse},
+            new Object[]{HEARING_REMINDER_NOTIFICATION, NO_HEARING_TYPE, expectedNumberOfLettersIsZero, isDocmosisLetterFalse},
+            new Object[]{EVIDENCE_RECEIVED_NOTIFICATION, ORAL, expectedNumberOfLettersIsZero, isDocmosisLetterFalse},
+            new Object[]{EVIDENCE_REMINDER_NOTIFICATION, PAPER, expectedNumberOfLettersIsZero, isDocmosisLetterFalse},
+            new Object[]{APPEAL_WITHDRAWN_NOTIFICATION, NO_HEARING_TYPE, expectedNumberOfLettersIsTwo, isDocmosisLetterFalse}
+            new Object[]{DIRECTION_ISSUED, NO_HEARING_TYPE, expectedNumberOfLettersIsTwo, isDocmosisLetterTrue}
         };
     }
 }

--- a/src/e2e/resources/jointParty/directionIssuedCallback.json
+++ b/src/e2e/resources/jointParty/directionIssuedCallback.json
@@ -1,0 +1,389 @@
+{
+  "case_details": {
+    "after_submit_callback_response": null,
+    "callback_response_status": null,
+    "callback_response_status_code": null,
+    "case_data": {
+      "directionTypeDl": "appealToProceed",
+      "createdInGapsFrom": "readyToList",
+      "jointParty": "Yes",
+      "jointPartyName": {
+        "title": "mr",
+        "firstName": "Joint",
+        "lastName": "Party"
+      },
+      "jointPartyAddressSameAsAppellant": "No",
+      "jointPartyAddress": {
+        "line1": "30 Dale Street",
+        "line2": "Village",
+        "town": "Liverpool",
+        "county": "Merseyside",
+        "postcode": "TS4 4ST"
+      },
+      "appeal": {
+        "mrnDetails": {
+          "dwpIssuingOffice": "Birmingham",
+          "mrnDate": "2018-01-01",
+          "mrnLateReason": "It is late",
+          "mrnMissingReason": "It went missing"
+        },
+        "appellant": {
+          "name": {
+            "title": "Mr",
+            "firstName": "Dexter",
+            "lastName": "Vasquez"
+          },
+          "address": {
+            "line1": "36 Dale Street",
+            "line2": "Village",
+            "town": "Liverpool",
+            "county": "Merseyside",
+            "postcode": "TS1 1ST"
+          },
+          "contact": {
+            "email": "sscstest+notify@greencroftconsulting.com",
+            "mobile": "07398785050"
+          },
+          "identity": {
+            "dob": "1998-07-01",
+            "nino": "JT098230B"
+          },
+          "isAddressSameAsAppointee":"no"
+        },
+        "benefitType":{
+          "code":"PIP"
+        },
+        "receivedVia": "Online",
+        "hearingOptions":{
+          "wantsToAttend":"Yes",
+          "wantsSupport":"No",
+          "languageInterpreter":"Yes",
+          "languages": "French",
+          "scheduleHearing": "Yes",
+          "other": "Bla",
+          "arrangements": [
+            "signLanguageInterpreter",
+            "hearingLoop"
+          ],
+          "excludeDates": [
+            {
+              "value": {
+                "start": "2018-04-04",
+                "end": "2018-04-06"
+              }
+            },
+            {
+              "value": {
+                "start": "2018-04-10"
+              }
+            }
+          ]
+        },
+        "appealReasons": {
+          "reasons": [
+            {
+              "value": {
+                "reason": "reason1",
+                "description": "description1"
+              }
+            },
+            {
+              "value": {
+                "reason": "reason2",
+                "description": "description2"
+              }
+            }
+          ],
+          "otherReasons": "Another reason"
+        },
+        "rep": {},
+        "signer":"Yes",
+        "supporter": {
+          "contact": {
+            "email": "sscstest+notify@greencroftconsulting.com",
+            "mobile": "07398785050"
+          },
+          "name": {
+            "firstName": "Guy",
+            "lastName": "Wilder",
+            "middleName": "Clark Eaton",
+            "title": "Mr"
+          }
+        },
+        "hearingType": ""
+      },
+      "informationFromAppellant": "No",
+      "evidence": {
+        "documents":[
+          {
+            "value": {
+              "dateReceived":"2018-01-04",
+              "evidenceType":"Medical Evidence",
+              "evidenceProvidedBy":"Appellant"
+            }
+          }
+        ]
+      },
+      "events": [
+        {
+          "id": "88888888-e24e-46de-b4b6-33dfbecccddc",
+          "value": {
+            "date": "2017-05-22T14:01:18.243",
+            "description": "Appeal received",
+            "type": "appealReceived"
+          }
+        },
+        {
+          "id": "960c715a-e24e-46de-b4b6-33dfbecccddc",
+          "value": {
+            "date": "2017-05-01T12:34:56.789",
+            "description": "Appeal received",
+            "type": "appealReceived"
+          }
+        },
+        {
+          "id": "960c715a-e24e-46de-b4b6-33dfbecccddc",
+          "value": {
+            "date": "2017-05-24T14:01:18.243",
+            "description": "DWP response received",
+            "type": "responseReceived"
+          }
+        },
+        {
+          "id": "208d1978-3434-4719-8c8a-5a613364e17e",
+          "value": {
+            "date": "2017-05-24T13:54:06.637",
+            "description": "Hearing booked",
+            "type": "hearingBooked"
+          }
+        }
+      ],
+      "caseCreated": "2018-02-13",
+      "caseReference": "SC022/14/12423",
+      "subscriptions": {
+        "appellantSubscription": {
+          "email": "sscstest+notify@greencroftconsulting.com",
+          "mobile": "07398785050",
+          "reason": null,
+          "subscribeEmail": "no",
+          "subscribeSms": "no",
+          "wantSmsNotifications" : "No",
+          "tya": "543212345"
+        },
+        "jointPartySubscription": {
+          "email": "sscstest+notify2@greencroftconsulting.com",
+          "mobile": "07398785051",
+          "reason": null,
+          "subscribeEmail": "Yes",
+          "subscribeSms": "Yes",
+          "wantSmsNotifications" : "Yes",
+          "tya": "232929249492"
+        }
+      },
+      "region" : "CARDIFF",
+      "regionalProcessingCenter" : {
+        "name" : "CARDIFF",
+        "address1" : "HM Courts & Tribunals Service",
+        "address2" : "Social Security & Child Support Appeals",
+        "address3" : "Eastgate House",
+        "address4" : "Newport Road",
+        "city" : "CARDIFF",
+        "postcode" : "CF24 0AB",
+        "phoneNumber" : "0300 123 1142",
+        "faxNumber" : "0870 739 4438"
+      },
+      "hearings": [{
+        "id": "1234",
+        "value": {
+          "hearingDate": "2048-01-12",
+          "time": "11:00",
+          "venue": {
+            "name": "Prudential House",
+            "address": {
+              "line1": "36 Dale Street",
+              "line2": "",
+              "town": "Liverpool",
+              "county": "Merseyside",
+              "postcode": "L2 5UZ"
+            },
+            "googleMapLink": "https://www.google.com/theAddress"
+          }
+        }
+      }]
+    },
+    "case_type_id": "Benefit",
+    "state": "appealCreated",
+    "created_date": [2019, 9, 1, 13, 20, 21, 73000000],
+    "id": "12345656789"
+  },
+  "case_details_before": {
+    "after_submit_callback_response": null,
+    "callback_response_status": null,
+    "callback_response_status_code": null,
+    "case_data": {
+      "directionTypeDl": "appealToProceed",
+      "jointParty": "Yes",
+      "jointPartyName": {
+        "title": "mr",
+        "firstName": "Joint",
+        "lastName": "Party"
+      },
+      "jointPartyAddressSameAsAppellant": "No",
+      "jointPartyAddress": {
+          "line1": "30 Dale Street",
+          "line2": "Village",
+          "town": "Liverpool",
+          "county": "Merseyside",
+          "postcode": "TS4 4ST"
+      },
+      "appeal": {
+        "mrnDetails": {
+          "dwpIssuingOffice": "Birmingham",
+          "mrnDate": "2018-01-01",
+          "mrnLateReason": "It is late",
+          "mrnMissingReason": "It went missing"
+        },
+        "appellant": {
+          "name": {
+            "title": "Mr",
+            "lastName": "Vasquez",
+            "firstName": "Dexter"
+          },
+          "address": {
+            "line1": "36 Dale Street",
+            "line2": "Village",
+            "town": "Liverpool",
+            "county": "Merseyside",
+            "postcode": "TS1 1ST"
+          },
+          "contact": {
+            "email": "sscstest+notify@greencroftconsulting.com",
+            "mobile": "07848484848"
+          },
+          "identity": {
+            "dob": "1998-07-01",
+            "nino": "JT098230B"
+          },
+          "isAddressSameAsAppointee":"no"
+        },
+        "benefitType": {
+          "code": "ESA"
+        },
+        "receivedVia": "Online",
+        "hearingOptions": {
+          "wantsToAttend": "Yes",
+          "wantsSupport": "No",
+          "languageInterpreter": "Yes",
+          "languages": "French",
+          "scheduleHearing": "Yes",
+          "other": "Bla",
+          "arrangements": [
+            "signLanguageInterpreter",
+            "hearingLoop"
+          ],
+          "excludeDates": [
+            {
+              "value": {
+                "start": "2018-04-04",
+                "end": "2018-04-06"
+              }
+            },
+            {
+              "value": {
+                "start": "2018-04-10"
+              }
+            }
+          ]
+        },
+        "appealReasons": {
+          "reasons": [
+            {
+              "value": {
+                "reason": "reason1",
+                "description": "description1"
+              }
+            },
+            {
+              "value": {
+                "reason": "reason2",
+                "description": "description2"
+              }
+            }
+          ],
+          "otherReasons": "Another reason"
+        },
+        "rep": {},
+        "signer": "Yes",
+        "supporter": {
+          "contact": {
+            "email": "sscstest+notify@greencroftconsulting.com",
+            "mobile": "07985223409"
+          },
+          "name": {
+            "firstName": "Guy",
+            "lastName": "Wilder",
+            "middleName": "Clark Eaton",
+            "title": "Mr"
+          }
+        }
+      },
+      "caseCreated": "2018-02-13",
+      "caseReference": "SC022/14/12423",
+      "subscriptions": {
+        "appellantSubscription": {
+          "email": "sscstest+notify@greencroftconsulting.com",
+          "mobile": "07398785050",
+          "reason": null,
+          "subscribeEmail": "No",
+          "subscribeSms": "No",
+          "wantSmsNotifications" : "No",
+          "tya": "543212345"
+        },
+        "jointPartySubscription": {
+          "email": "sscstest+notify2@greencroftconsulting.com",
+          "mobile": "07398785051",
+          "reason": null,
+          "subscribeEmail": "Yes",
+          "subscribeSms": "Yes",
+          "wantSmsNotifications" : "Yes",
+          "tya": "232929249492"
+        }
+      },
+      "region": "CARDIFF",
+      "regionalProcessingCenter": {
+        "name": "CARDIFF",
+        "address1": "HM Courts & Tribunals Service",
+        "address2": "Social Security & Child Support Appeals",
+        "address3": "Eastgate House",
+        "address4": "Newport Road",
+        "city": "CARDIFF",
+        "postcode": "CF24 0AB",
+        "phoneNumber": "0300 123 1142",
+        "faxNumber": "0870 739 4438"
+      },
+      "hearings": [{
+        "id": "1234",
+        "value": {
+          "hearingDate": "2018-01-12",
+          "time": "11:00",
+          "venue": {
+            "name": "Prudential House",
+            "address": {
+              "line1": "36 Dale Street",
+              "line2": "",
+              "town": "Liverpool",
+              "county": "Merseyside",
+              "postcode": "L2 5UZ"
+            },
+            "googleMapLink": "https://www.google.com/theAddress"
+          }
+          }
+        }
+      ]
+    },
+    "case_type_id": "Benefit",
+    "state": "appealCreated",
+    "id": "12345656789"
+  },
+  "event_id": "directionIssued"
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/config/AppConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/config/AppConstants.java
@@ -38,6 +38,7 @@ public final class AppConstants {
     public static final String FIRST_TIER_AGENCY_ACRONYM = "first_tier_agency_acronym";
     public static final String FIRST_TIER_AGENCY_FULL_NAME = "first_tier_agency_full_name";
     public static final String REPRESENTATIVE = "representative";
+    public static final String JOINT_PARTY = "joint_party";
     public static final String HEARING_ARRANGEMENT_DETAILS_LITERAL = "hearing_arrangement_details";
     public static final String WELSH_HEARING_ARRANGEMENT_DETAILS_LITERAL = "welsh_hearing_arrangement_details";
     public static final String HEARING_CONTACT_DATE = "hearing_contact_date";

--- a/src/main/java/uk/gov/hmcts/reform/sscs/factory/CcdNotificationWrapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/factory/CcdNotificationWrapper.java
@@ -224,6 +224,7 @@ public class CcdNotificationWrapper implements NotificationWrapper {
             || EVIDENCE_RECEIVED_NOTIFICATION.equals(getNotificationType())
             || APPEAL_WITHDRAWN_NOTIFICATION.equals(getNotificationType())
             || ADMIN_APPEAL_WITHDRAWN.equals(getNotificationType())
+            || DIRECTION_ISSUED.equals(getNotificationType())
             || EVIDENCE_REMINDER_NOTIFICATION.equals(getNotificationType()))
         ) {
             subscriptionWithTypeList.add(new SubscriptionWithType(getJointPartySubscription(), JOINT_PARTY));

--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
@@ -338,6 +338,9 @@ public class Personalisation<E extends NotificationWrapper> {
         if (subscriptionWithType.getSubscriptionType().equals(REPRESENTATIVE)) {
             personalisation.put(AppConstants.REPRESENTATIVE, "Yes");
         }
+        if (subscriptionWithType.getSubscriptionType().equals(JOINT_PARTY)) {
+            personalisation.put(AppConstants.JOINT_PARTY, "Yes");
+        }
 
         return personalisation;
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -316,6 +316,8 @@ notification:
           docmosisId: TB-SCS-GNO-ENG-00551.docx
         representative:
           docmosisId: TB-SCS-GNO-ENG-00551.docx
+        joint_party:
+          docmosisId: TB-SCS-GNO-ENG-00551.docx
       provideInformation:
         appellant:
           docmosisId: TB-SCS-GNO-ENG-00067.docx

--- a/src/test/java/uk/gov/hmcts/reform/sscs/factory/CcdNotificationWrapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/factory/CcdNotificationWrapperTest.java
@@ -189,7 +189,7 @@ public class CcdNotificationWrapperTest {
     @Test
     @Parameters({"APPEAL_LAPSED_NOTIFICATION, paper", "APPEAL_LAPSED_NOTIFICATION, oral", "EVIDENCE_REMINDER_NOTIFICATION, oral", "EVIDENCE_REMINDER_NOTIFICATION, paper",
             "APPEAL_DORMANT_NOTIFICATION, paper", "APPEAL_DORMANT_NOTIFICATION, oral", "ADJOURNED_NOTIFICATION, paper", "ADJOURNED_NOTIFICATION, oral", "POSTPONEMENT_NOTIFICATION, paper", "POSTPONEMENT_NOTIFICATION, oral",
-            "EVIDENCE_RECEIVED_NOTIFICATION, paper", "EVIDENCE_RECEIVED_NOTIFICATION, oral", "APPEAL_WITHDRAWN_NOTIFICATION, paper",
+            "EVIDENCE_RECEIVED_NOTIFICATION, paper", "EVIDENCE_RECEIVED_NOTIFICATION, oral", "APPEAL_WITHDRAWN_NOTIFICATION, paper", "DIRECTION_ISSUED, oral", "DIRECTION_ISSUED, paper",
             "HEARING_BOOKED_NOTIFICATION, oral", "HEARING_BOOKED_NOTIFICATION, paper",  "HEARING_REMINDER_NOTIFICATION, oral", "HEARING_REMINDER_NOTIFICATION, paper"})
     public void givenSubscriptions_shouldGetSubscriptionTypeListWithAppointeeAndJointParty(NotificationEventType notificationEventType, String hearingType) {
         ccdNotificationWrapper = buildCcdNotificationWrapperBasedOnEventTypeWithAppointeeAndJointParty(notificationEventType, hearingType);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
@@ -49,6 +49,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
+import uk.gov.hmcts.reform.sscs.config.AppConstants;
 import uk.gov.hmcts.reform.sscs.config.AppealHearingType;
 import uk.gov.hmcts.reform.sscs.config.NotificationConfig;
 import uk.gov.hmcts.reform.sscs.config.SubscriptionType;
@@ -170,6 +171,7 @@ public class PersonalisationTest {
 
     @Test
     @Parameters({"APPEAL_TO_PROCEED, directionIssued.appealToProceed, APPELLANT",
+            "APPEAL_TO_PROCEED, directionIssued.appealToProceed, JOINT_PARTY",
             "PROVIDE_INFORMATION, directionIssued.provideInformation, REPRESENTATIVE",
             "GRANT_EXTENSION, directionIssued.grantExtension, APPOINTEE",
             "REFUSE_EXTENSION, directionIssued.refuseExtension, APPELLANT"})
@@ -386,6 +388,7 @@ public class PersonalisationTest {
         assertEquals("http://link.com/progress/GLSCRR/abouthearing", result.get(HEARING_INFO_LINK_LITERAL));
         assertNull(result.get(EVIDENCE_RECEIVED_DATE_LITERAL));
         assertEquals(EMPTY, result.get(JOINT));
+        assertNull(result.get(AppConstants.JOINT_PARTY));
 
         assertEquals(ADDRESS1, result.get(REGIONAL_OFFICE_NAME_LITERAL));
         assertEquals(ADDRESS2, result.get(SUPPORT_CENTRE_NAME_LITERAL));
@@ -1188,6 +1191,7 @@ public class PersonalisationTest {
         assertEquals("http://tyalink.com/" + jointPartyTyaNumber, result.get(TRACK_APPEAL_LINK_LITERAL));
         assertEquals("http://link.com/" + jointPartyTyaNumber, result.get(SUBMIT_EVIDENCE_LINK_LITERAL));
         assertEquals("http://link.com/" + jointPartyTyaNumber, result.get(SUBMIT_EVIDENCE_INFO_LINK_LITERAL));
+        assertEquals("Yes", result.get(AppConstants.JOINT_PARTY));
     }
 
     @Test


### PR DESCRIPTION
SSCS-7953 - Directions - Appeal to Proceed for Joint Party

Added "joint_party" to 'Yes' when the subscription type is for a joint party
Modified existing template for a joint party

An example letter for direction issued - appeal to proceed is [here](https://www.notifications.service.gov.uk/services/cf23bf9c-4a42-42d1-a734-5cfc53dda6ca/notification/1801e2c2-0c52-4bf3-9b3b-ec313b95c39a)
