### PR TITLE
Sscs 7947 upload response joint party paper sms fix

### DIFF
--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/NotificationsIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/NotificationsIt.java
@@ -824,7 +824,7 @@ public class NotificationsIt {
                         DWP_UPLOAD_RESPONSE_NOTIFICATION,
                         "paper",
                         Collections.singletonList("8c4770ca-13c9-49ea-9df1-f2952030f95e"),
-                        Collections.singletonList("5e5cfe8d-b893-4f87-817f-9d05d22d657a"),
+                        Collections.singletonList("15cd6837-e998-4bf9-a815-af3e98922d19"),
                         Arrays.asList("TB-SCS-GNO-ENG-00261.docx", "TB-SCS-GNO-ENG-00261.docx"),
                         "yes",
                         "yes",

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -433,7 +433,7 @@ notification:
           smsId: b2d187cd-089b-4fe1-b460-a310c0af46fe
         joint_party:
           emailId: 8c4770ca-13c9-49ea-9df1-f2952030f95e
-          smsId: 5e5cfe8d-b893-4f87-817f-9d05d22d657a
+          smsId: 15cd6837-e998-4bf9-a815-af3e98922d19
       appealDormant:
         appellant:
           emailId: 976bdb6c-8a86-48cf-9e0f-7989acaec0c2


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-7937

### Change description ###

Migrating joint party paper upload response sms template to its own version, with custom text

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
