### PR TITLE
SSCS-10166-Upgrade/Fix poi and commons-beanutils vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -373,7 +373,7 @@ dependencies {
     compile group: 'com.github.hmcts', name: 'java-logging', version: versions.reformLogging
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '4.0.0'
     compile group: 'com.github.hmcts', name: 'sscs-common', version: '4.6.45-RC-SSCS-10166'
-    compile group: 'com.github.hmcts', name: 'sscs-pdf-email-common', version: '1.4.52'
+    compile group: 'com.github.hmcts', name: 'sscs-pdf-email-common', version: '1.4.54-RC-SSCS-10166'
 
     compile group: 'com.github.hmcts', name: 'sscs-job-scheduler', version: '1.5.7'
 

--- a/build.gradle
+++ b/build.gradle
@@ -372,7 +372,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version:'0.1.0'
     compile group: 'com.github.hmcts', name: 'java-logging', version: versions.reformLogging
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '4.0.0'
-    compile group: 'com.github.hmcts', name: 'sscs-common', version: '4.6.38'
+    compile group: 'com.github.hmcts', name: 'sscs-common', version: '4.6.45-RC-SSCS-10166'
     compile group: 'com.github.hmcts', name: 'sscs-pdf-email-common', version: '1.4.52'
 
     compile group: 'com.github.hmcts', name: 'sscs-job-scheduler', version: '1.5.7'
@@ -405,7 +405,11 @@ dependencies {
     }
     testCompile group: 'org.mockito', name: 'mockito-core', version: '4.2.0'
     testCompile 'pl.pragmatists:JUnitParams:1.1.1'
-    testCompile 'com.github.hmcts:fortify-client:1.2.1:all'
+    integrationTestCompile group: 'com.github.hmcts', name: 'fortify-client', version: '1.2.2', classifier: 'all', {
+        exclude group: 'commons-io', module: 'commons-io'
+    }
+    compile group: 'commons-io', name: 'commons-io', version: '2.11.0'
+    integrationTestCompile group: 'commons-io', name: 'commons-io', version: '2.11.0'
 
     runtime "org.springframework.boot:spring-boot-properties-migrator"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -405,7 +405,7 @@ dependencies {
     }
     testCompile group: 'org.mockito', name: 'mockito-core', version: '4.2.0'
     testCompile 'pl.pragmatists:JUnitParams:1.1.1'
-    integrationTestCompile group: 'com.github.hmcts', name: 'fortify-client', version: '1.2.2', classifier: 'all', {
+    testCompile group: 'com.github.hmcts', name: 'fortify-client', version: '1.2.2', classifier: 'all', {
         exclude group: 'commons-io', module: 'commons-io'
     }
     compile group: 'commons-io', name: 'commons-io', version: '2.11.0'


### PR DESCRIPTION
Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-10166


### Change description ###
poi and opencvs versions are updated in sscs-common and sscs-pdf-email-common as the security vulnerabilities they have are preventing feature developments


**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
