### PR TITLE
Revert "Disable functional tests as notifications are not sent out of hours"

### DIFF
--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/handlers/AdminAppealWithdrawnNotificationsTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/handlers/AdminAppealWithdrawnNotificationsTest.java
@@ -11,7 +11,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import junitparams.Parameters;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -41,7 +40,6 @@ public class AdminAppealWithdrawnNotificationsTest extends AbstractFunctionalTes
     }
 
     @Test
-    @Ignore
     @Parameters({
         "Appellant, 8620e023-f663-477e-a771-9cfad50ee30f, 446c7b23-7342-42e1-adff-b4c367e951cb, 1, 1, 1",
         "Appointee, 8620e023-f663-477e-a771-9cfad50ee30f, 446c7b23-7342-42e1-adff-b4c367e951cb, 1, 1, 1",

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/DocmosisWithGovNotifyLetterFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/DocmosisWithGovNotifyLetterFunctionalTest.java
@@ -64,7 +64,6 @@ public class DocmosisWithGovNotifyLetterFunctionalTest extends AbstractFunctiona
     }
 
     @Test
-    @Ignore
     @Parameters(method = "expectedNumberOfLetters")
     public void shouldSendCorrectNumberOfDocmosisLetters(NotificationEventType notificationEventType,
                                                          int expectedNumberOfLetters)

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/EvidenceReceivedFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/EvidenceReceivedFunctionalTest.java
@@ -8,7 +8,6 @@ import java.lang.reflect.Field;
 import java.util.List;
 import junitparams.Parameters;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
 import uk.gov.hmcts.reform.sscs.config.AppealHearingType;
@@ -39,7 +38,6 @@ public class EvidenceReceivedFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     @Parameters({"ORAL", "PAPER"})
     public void givenEvidenceReceivedWithRepsSubscription_shouldSendNotificationToReps(AppealHearingType appealHearingType)
             throws Exception {

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/JointPartyFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/JointPartyFunctionalTest.java
@@ -135,7 +135,6 @@ public class JointPartyFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void sendsDirectionIssuedProvideInformationLetterToAppellantRepresentativeAndJointParty() throws IOException, NotificationClientException {
 
         NotificationEventType notificationEventType = NotificationEventType.DIRECTION_ISSUED;

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/NotificationsFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/NotificationsFunctionalTest.java
@@ -155,7 +155,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendEvidenceReceivedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(EVIDENCE_RECEIVED);
 
@@ -167,7 +166,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
 
 
     @Test
-    @Ignore
     public void shouldSendHearingPostponedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(POSTPONEMENT);
 
@@ -175,7 +173,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendHearingAdjournedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(ADJOURNED);
 
@@ -186,7 +183,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendSubscriptionCreatedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(SUBSCRIPTION_CREATED);
 
@@ -194,7 +190,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendSubscriptionUpdatedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(SUBSCRIPTION_UPDATED);
 
@@ -202,7 +197,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppealCreatedAppellantNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(SYA_APPEAL_CREATED, SYA_APPEAL_CREATED.getId() + "Callback.json");
         List<Notification> notifications = tryFetchNotificationsForTestCase(appealCreatedAppellantEmailId, appealCreatedAppellantSmsId);
@@ -211,7 +205,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendValidAppealCreatedAppellantNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(VALID_APPEAL_CREATED, SYA_APPEAL_CREATED.getId() + "Callback.json");
         List<Notification> notifications = tryFetchNotificationsForTestCase(appealCreatedAppellantEmailId, appealCreatedAppellantSmsId);
@@ -220,7 +213,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppealCreatedAppointeeNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(SYA_APPEAL_CREATED, SYA_APPEAL_CREATED.getId() + "AppointeeCallback.json");
         List<Notification> notifications = tryFetchNotificationsForTestCase(appealCreatedAppointeeEmailId, appealCreatedAppointeeSmsId);
@@ -229,7 +221,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendValidAppealCreatedAppointeeNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(VALID_APPEAL_CREATED, SYA_APPEAL_CREATED.getId() + "AppointeeCallback.json");
         List<Notification> notifications = tryFetchNotificationsForTestCase(appealCreatedAppointeeEmailId, appealCreatedAppointeeSmsId);
@@ -238,7 +229,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     @Parameters({
         "pip,judge\\, doctor and disability expert",
         "esa,judge and a doctor",
@@ -261,7 +251,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldNotSendPaperDwpResponseReceivedNotificationIfNotSubscribed() throws NotificationClientException, IOException {
         simulateCcdCallback(DWP_RESPONSE_RECEIVED, RESPONSE_RECEIVED_PAPER_PATH + "paper-no-subscriptions-"
                 + DWP_RESPONSE_RECEIVED.getId() + "Callback.json");
@@ -273,7 +262,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeEvidenceReminderForOralCaseNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(EVIDENCE_REMINDER,
                 "appointee/oral-" + EVIDENCE_REMINDER.getId() + "Callback.json");
@@ -293,7 +281,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeEvidenceReminderForPaperCaseNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(EVIDENCE_REMINDER,
                 "appointee/paper-" + EVIDENCE_REMINDER.getId() + "Callback.json");
@@ -313,7 +300,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppellantSubscriptionUpdateNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(SUBSCRIPTION_UPDATED,
                 "appellant-" + SUBSCRIPTION_UPDATED.getId() + "Callback.json");
@@ -331,7 +317,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeSubscriptionUpdateNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(SUBSCRIPTION_UPDATED,
                 "appointee-" + SUBSCRIPTION_UPDATED.getId() + "Callback.json");
@@ -347,7 +332,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeEvidenceReceivedPaperNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(EVIDENCE_RECEIVED,
                 "appointee/paper-" + EVIDENCE_RECEIVED.getId() + "Callback.json");
@@ -362,7 +346,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeHearingAdjournedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(ADJOURNED,
                 "appointee/" + ADJOURNED.getId() + "Callback.json");
@@ -376,7 +359,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeAppealLapsedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(APPEAL_LAPSED,
                 "appointee/" + APPEAL_LAPSED.getId() + "Callback.json");
@@ -395,7 +377,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeDwpAppealLapsedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(APPEAL_LAPSED,
                 "appointee/dwpAppealLapsedCallback.json");
@@ -410,7 +391,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeResponseReceivedForPaperCaseNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(DWP_RESPONSE_RECEIVED,
                 "appointee/" + DWP_RESPONSE_RECEIVED.getId() + "Callback.json");
@@ -455,7 +435,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeEvidenceReceivedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(EVIDENCE_RECEIVED,
                 "appointee/" + EVIDENCE_RECEIVED.getId() + "Callback.json");
@@ -466,7 +445,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeHearingPostponedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(POSTPONEMENT,
                 "appointee/" + POSTPONEMENT.getId() + "Callback.json");
@@ -478,7 +456,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSaveReasonableAdjustmentNotificationForAppellant() throws IOException {
         simulateCcdCallback(APPEAL_RECEIVED, APPEAL_RECEIVED.getId() + "AppellantReasonableAdjustmentCallback.json");
 
@@ -493,7 +470,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSaveReasonableAdjustmentNotificationForAppellantAndRep() throws IOException {
         simulateCcdCallback(APPEAL_RECEIVED, APPEAL_RECEIVED.getId() + "AppellantRepReasonableAdjustmentCallback.json");
 

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/OtherPartyFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/OtherPartyFunctionalTest.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.List;
 import junitparams.Parameters;
 import junitparams.converters.Nullable;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
@@ -47,7 +46,6 @@ public class OtherPartyFunctionalTest extends AbstractFunctionalTest {
 
 
     @Test
-    @Ignore
     @Parameters({"oral-,DWP_UPLOAD_RESPONSE, oralDwpUploadResponseJointPartySmsId, oralDwpUploadResponseOtherPartyEmailId"})
     public void willSendDwpUploadResponse(@Nullable String prefix, NotificationEventType notificationEventType, String... fieldNames) throws Exception {
 
@@ -67,7 +65,6 @@ public class OtherPartyFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     @Parameters({
         "ADJOURNED, 0, hearingAdjournedOtherPartyEmailTemplateId, hearingAdjournedOtherPartySmsTemplateId",
         "POSTPONEMENT, 2, hearingPostponedOtherPartyEmailTemplateId",

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/WelshNotificationsFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/WelshNotificationsFunctionalTest.java
@@ -176,7 +176,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendEvidenceReceivedNotificationWelsh() throws NotificationClientException, IOException {
         simulateWelshCcdCallback(EVIDENCE_RECEIVED);
         tryFetchNotificationsForTestCase(
@@ -188,7 +187,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendPaperEvidenceReceivedNotificationWelsh() throws NotificationClientException, IOException {
         simulateCcdCallback(EVIDENCE_RECEIVED, "paper-" + EVIDENCE_RECEIVED.getId() + "CallbackWelsh.json");
         tryFetchNotificationsForTestCase(
@@ -201,7 +199,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
 
 
     @Test
-    @Ignore
     public void shouldSendHearingPostponedNotificationWelsh() throws NotificationClientException, IOException {
         simulateWelshCcdCallback(POSTPONEMENT);
 
@@ -224,7 +221,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
 
 
     @Test
-    @Ignore
     public void shouldSendHearingAdjournedNotificationWelsh() throws NotificationClientException, IOException {
         simulateWelshCcdCallback(ADJOURNED);
 
@@ -237,7 +233,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendSubscriptionCreatedNotificationWelsh() throws NotificationClientException, IOException {
 
         simulateWelshCcdCallback(SUBSCRIPTION_CREATED);
@@ -247,7 +242,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
 
 
     @Test
-    @Ignore
     public void shouldSendSubscriptionUpdatedNotificationWelsh() throws NotificationClientException, IOException {
         simulateWelshCcdCallback(SUBSCRIPTION_UPDATED);
 
@@ -255,7 +249,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppealCreatedAppellantNotificationWelsh() throws NotificationClientException, IOException {
         simulateCcdCallback(SYA_APPEAL_CREATED, SYA_APPEAL_CREATED.getId() + "CallbackWelsh.json");
         List<Notification> notifications = tryFetchNotificationsForTestCase(appealCreatedAppellantEmailIdWelsh, appealCreatedAppellantSmsIdWelsh);
@@ -265,7 +258,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
 
 
     @Test
-    @Ignore
     public void shouldSendValidAppealCreatedAppellantNotificationWelsh() throws NotificationClientException, IOException {
         simulateCcdCallback(VALID_APPEAL_CREATED, SYA_APPEAL_CREATED.getId() + "CallbackWelsh.json");
         List<Notification> notifications = tryFetchNotificationsForTestCase(appealCreatedAppellantEmailIdWelsh, appealCreatedAppellantSmsIdWelsh);
@@ -274,7 +266,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppealCreatedAppointeeNotificationWelsh() throws NotificationClientException, IOException {
         simulateCcdCallback(SYA_APPEAL_CREATED, SYA_APPEAL_CREATED.getId() + "AppointeeCallbackWelsh.json");
         List<Notification> notifications = tryFetchNotificationsForTestCase(appealCreatedAppointeeEmailIdWelsh, appealCreatedAppointeeSmsIdWelsh);
@@ -284,7 +275,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
 
 
     @Test
-    @Ignore
     public void shouldSendValidAppealCreatedAppointeeNotificationWelsh() throws NotificationClientException, IOException {
         simulateCcdCallback(VALID_APPEAL_CREATED, SYA_APPEAL_CREATED.getId() + "AppointeeCallbackWelsh.json");
         List<Notification> notifications = tryFetchNotificationsForTestCase(appealCreatedAppointeeEmailIdWelsh, appealCreatedAppointeeSmsIdWelsh);
@@ -293,7 +283,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeEvidenceReminderForPaperCaseNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(EVIDENCE_REMINDER,
                 "appointee/paper-" + EVIDENCE_REMINDER.getId() + "CallbackWelsh.json");
@@ -315,7 +304,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendPaperAppealDormantNotificationWelsh() throws NotificationClientException, IOException {
         simulateCcdCallback(APPEAL_DORMANT, "paper-" + APPEAL_DORMANT.getId() + "CallbackWelsh.json");
         tryFetchNotificationsForTestCase(
@@ -326,14 +314,12 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendOralAppealDormantNotificationWelsh() throws NotificationClientException, IOException {
         simulateCcdCallback(APPEAL_DORMANT, "oral-" + APPEAL_DORMANT.getId() + "CallbackWelsh.json");
         tryFetchNotificationsForTestCase(appealDormantOralJointPartyEmailTemplateIdWelsh, appealDormantOralAppellantEmailTemplateIdWelsh);
     }
 
     @Test
-    @Ignore
     public void shouldSendAppealLapsedNotificationToAppointeeJointPartyAndRep() throws NotificationClientException, IOException {
         simulateCcdCallback(APPEAL_LAPSED,
                 "appointee/" + APPEAL_LAPSED.getId() + "CallbackWelsh.json");
@@ -357,7 +343,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeAppealWithdrawnNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(APPEAL_WITHDRAWN,
                 "appointee/" + APPEAL_WITHDRAWN.getId() + "CallbackWelsh.json");
@@ -384,7 +369,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeEvidenceReminderForOralCaseNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(EVIDENCE_REMINDER,
                 "appointee/oral-" + EVIDENCE_REMINDER.getId() + "CallbackWelsh.json");
@@ -406,7 +390,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     @Parameters(method = "docmosisTestSetup")
     public void shouldSendDocmosisLettersViaGovNotify(NotificationEventType notificationEventType,
                                                       Optional<String> resourceParam,

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/WithRepresentativePersonalisationTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/notifications/WithRepresentativePersonalisationTest.java
@@ -5,7 +5,6 @@ import static uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType.*;
 import java.lang.reflect.Field;
 import java.util.List;
 import junitparams.Parameters;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
 import uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType;
@@ -92,7 +91,6 @@ public class WithRepresentativePersonalisationTest extends AbstractFunctionalTes
     }
 
     @Test
-    @Ignore
     @Parameters(method = "eventTypeAndSubscriptions")
     public void givenEventAndRepsSubscription_shouldSendNotificationToReps(NotificationEventType notificationEventType)
             throws Exception {
@@ -111,7 +109,6 @@ public class WithRepresentativePersonalisationTest extends AbstractFunctionalTes
     }
 
     @Test
-    @Ignore
     public void givenHearingPostponedEventAndRepsSubscription_shouldSendEmailOnlyNotificationToReps()
             throws Exception {
 


### PR DESCRIPTION
Reverts hmcts/sscs-track-your-appeal-notifications#2452