### PR TITLE
Remove dependency check from pre-commit checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,6 @@ task runGitPreCommitTasks {
     dependsOn 'test'
     dependsOn 'pmdMain'
     dependsOn 'pmdTest'
-    dependsOn 'dependencyCheckAggregate'
     dependsOn 'checkstyleMain'
     dependsOn 'checkstyleTest'
 }


### PR DESCRIPTION
Remove dependency check from pre-commit checks since it is run efficiently in the pipeline