### PR TITLE
Update sscs-common to 5.3.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -358,7 +358,7 @@ dependencies {
 
     implementation group: 'com.github.hmcts', name: 'cmc-pdf-service-client', version: '7.0.1'
 
-    implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5.3.3'
+    implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5.3.4'
     implementation group: 'com.github.hmcts', name: 'sscs-pdf-email-common', version: '5.2.4'
 
     implementation group: 'com.github.hmcts', name: 'sscs-job-scheduler', version: '1.5.7', {

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -15,6 +15,5 @@
         <cve>CVE-2023-35116</cve>
         <cve>CVE-2021-46877</cve>
         <cve>CVE-2023-6378</cve>
-        <cve>CVE-2024-25710</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/SSCSCI-769

### Change description ###

- Updated sscs-common to 5.3.4
- Removed CVE-2024-25710 because that was coming from sscs-common.