### PR TITLE
SSCSCI-830 - Dwp Response Date Notifications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -358,7 +358,7 @@ dependencies {
 
     implementation group: 'com.github.hmcts', name: 'cmc-pdf-service-client', version: '7.0.1'
 
-    implementation group: 'com.github.hmcts', name: 'sscs-common', version: '42224ac'
+    implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5.4.0'
     implementation group: 'com.github.hmcts', name: 'sscs-pdf-email-common', version: '5.2.5'
 
     implementation group: 'com.github.hmcts', name: 'sscs-job-scheduler', version: '1.5.7', {

--- a/build.gradle
+++ b/build.gradle
@@ -358,7 +358,7 @@ dependencies {
 
     implementation group: 'com.github.hmcts', name: 'cmc-pdf-service-client', version: '7.0.1'
 
-    implementation group: 'com.github.hmcts', name: 'sscs-common', version: '64da578'
+    implementation group: 'com.github.hmcts', name: 'sscs-common', version: '42224ac'
     implementation group: 'com.github.hmcts', name: 'sscs-pdf-email-common', version: '5.2.5'
 
     implementation group: 'com.github.hmcts', name: 'sscs-job-scheduler', version: '1.5.7', {

--- a/build.gradle
+++ b/build.gradle
@@ -358,7 +358,7 @@ dependencies {
 
     implementation group: 'com.github.hmcts', name: 'cmc-pdf-service-client', version: '7.0.1'
 
-    implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5.4.0'
+    implementation group: 'com.github.hmcts', name: 'sscs-common', version: '64da578'
     implementation group: 'com.github.hmcts', name: 'sscs-pdf-email-common', version: '5.2.5'
 
     implementation group: 'com.github.hmcts', name: 'sscs-job-scheduler', version: '1.5.7', {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/config/AppConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/config/AppConstants.java
@@ -29,6 +29,8 @@ public final class AppConstants {
     public static final String THE_STRING_WELSH = "yr ";
     public static final String TOMORROW_STRING = "tomorrow";
     public static final String ZONE_ID = "Europe/London";
+    public static final int MAX_DWP_RESPONSE_DAYS = 28;
+    public static final int MAX_DWP_RESPONSE_DAYS_CHILD_SUPPORT = 42;
 
     private AppConstants() {
         //

--- a/src/main/java/uk/gov/hmcts/reform/sscs/config/AppConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/config/AppConstants.java
@@ -29,7 +29,6 @@ public final class AppConstants {
     public static final String THE_STRING_WELSH = "yr ";
     public static final String TOMORROW_STRING = "tomorrow";
     public static final String ZONE_ID = "Europe/London";
-    public static final int MAX_DWP_RESPONSE_DAYS = 35;
 
     private AppConstants() {
         //

--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
@@ -490,8 +490,7 @@ public class Personalisation<E extends NotificationWrapper> {
 
     Map<String, Object> setEventData(Map<String, Object> personalisation, SscsCaseData ccdResponse, NotificationEventType notificationEventType) {
         if (ccdResponse.getCreatedInGapsFrom() != null && ccdResponse.getCreatedInGapsFrom().equals("readyToList")) {
-            int dwpResponseDays = ofNullable(dwpResponseUtil.calculateMaxDwpResponseDays(ccdResponse.getBenefitCode())).orElse(dwpResponseUtil.MAX_DWP_RESPONSE_DAYS);
-            LocalDate localDate = LocalDate.parse(ofNullable(ccdResponse.getDateSentToDwp()).orElse(LocalDate.now().toString())).plusDays(dwpResponseDays);
+            LocalDate localDate = LocalDate.parse(ofNullable(ccdResponse.getDateSentToDwp()).orElse(LocalDate.now().toString())).plusDays(dwpResponseUtil.calculateMaxDwpResponseDays(ccdResponse.getBenefitCode()));
             String dwpResponseDateString = formatLocalDate(localDate);
             personalisation.put(APPEAL_RESPOND_DATE, dwpResponseDateString);
             translateToWelshDate(localDate, ccdResponse, value ->
@@ -542,8 +541,7 @@ public class Personalisation<E extends NotificationWrapper> {
     }
 
     private Map<String, Object> setAppealReceivedDetails(Map<String, Object> personalisation, EventDetails eventDetails, SscsCaseData ccdResponse) {
-        int dwpResponseDays = ofNullable(dwpResponseUtil.calculateMaxDwpResponseDays(ccdResponse.getBenefitCode())).orElse(dwpResponseUtil.MAX_DWP_RESPONSE_DAYS);
-        LocalDate localDate = eventDetails.getDateTime().plusDays(dwpResponseDays).toLocalDate();
+        LocalDate localDate = eventDetails.getDateTime().plusDays(dwpResponseUtil.calculateMaxDwpResponseDays(ccdResponse.getBenefitCode())).toLocalDate();
         String dwpResponseDateString = formatLocalDate(localDate);
         personalisation.put(APPEAL_RESPOND_DATE, dwpResponseDateString);
         translateToWelshDate(localDate, ccdResponse, value ->

--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
@@ -540,7 +540,7 @@ public class Personalisation<E extends NotificationWrapper> {
     }
 
     private Map<String, Object> setAppealReceivedDetails(Map<String, Object> personalisation, EventDetails eventDetails, SscsCaseData ccdResponse) {
-        LocalDate localDate = eventDetails.getDateTime().plusDays(calculateMaxDwpResponseDays(ccdResponse.getBenefitCode())).toLocalDate();
+        LocalDate localDate = eventDetails.getDateTime().plusDays(calculateMaxDwpResponseDays(ccdResponse.getAppeal().getBenefitType().getCode())).toLocalDate();
         String dwpResponseDateString = formatLocalDate(localDate);
         personalisation.put(APPEAL_RESPOND_DATE, dwpResponseDateString);
         translateToWelshDate(localDate, ccdResponse, value ->

--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
@@ -741,11 +741,10 @@ public class Personalisation<E extends NotificationWrapper> {
     }
 
     public static int calculateMaxDwpResponseDays(String benefitCode) {
-        if (benefitCode == "childSupport" ) {
+        if (benefitCode == "childSupport") {
             return MAX_DWP_RESPONSE_DAYS_CHILD_SUPPORT;
-        }
-        else {
+        } else {
             return MAX_DWP_RESPONSE_DAYS;
         }
-    };
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
@@ -506,7 +506,7 @@ public class Personalisation<E extends NotificationWrapper> {
                     || notificationEventType.equals(CASE_UPDATED)
                     || JUDGE_DECISION_APPEAL_TO_PROCEED.equals(notificationEventType)
                     || TCW_DECISION_APPEAL_TO_PROCEED.equals(notificationEventType)) {
-                    return setSentToDWPDetails(personalisation, event.getValue(), ccdResponse);
+                    return setSentToDwpDetails(personalisation, event.getValue(), ccdResponse);
                 }
             }
         }
@@ -540,7 +540,7 @@ public class Personalisation<E extends NotificationWrapper> {
 
     }
 
-    private Map<String, Object> setSentToDWPDetails(Map<String, Object> personalisation, EventDetails eventDetails, SscsCaseData ccdResponse) {
+    private Map<String, Object> setSentToDwpDetails(Map<String, Object> personalisation, EventDetails eventDetails, SscsCaseData ccdResponse) {
         LocalDate localDate = eventDetails.getDateTime().plusDays(dwpResponseUtil.calculateMaxDwpResponseDays(ccdResponse.getBenefitCode())).toLocalDate();
         String dwpResponseDateString = formatLocalDate(localDate);
         personalisation.put(APPEAL_RESPOND_DATE, dwpResponseDateString);

--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
@@ -741,7 +741,7 @@ public class Personalisation<E extends NotificationWrapper> {
     }
 
     public static int calculateMaxDwpResponseDays(String benefitCode) {
-        if (benefitCode.equals("childSupport")) {
+        if (benefitCode != null && benefitCode.equals("childSupport")) {
             return MAX_DWP_RESPONSE_DAYS_CHILD_SUPPORT;
         } else {
             return MAX_DWP_RESPONSE_DAYS;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
@@ -638,6 +638,14 @@ public class Personalisation<E extends NotificationWrapper> {
                 benefit, notificationWrapper, notificationWrapper.getNewSscsCaseData().getCreatedInGapsFrom());
     }
 
+    public int calculateMaxDwpResponseDays(String benefitCode) {
+        if (benefitCode != null && benefitCode.equals("childSupport")) {
+            return MAX_DWP_RESPONSE_DAYS_CHILD_SUPPORT;
+        } else {
+            return MAX_DWP_RESPONSE_DAYS;
+        }
+    }
+
     private String getEmailTemplateName(SubscriptionType subscriptionType,
                                         NotificationWrapper notificationWrapper) {
 
@@ -740,11 +748,4 @@ public class Personalisation<E extends NotificationWrapper> {
             subscriptionType.name().toLowerCase());
     }
 
-    public static int calculateMaxDwpResponseDays(String benefitCode) {
-        if (benefitCode != null && benefitCode.equals("childSupport")) {
-            return MAX_DWP_RESPONSE_DAYS_CHILD_SUPPORT;
-        } else {
-            return MAX_DWP_RESPONSE_DAYS;
-        }
-    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
@@ -741,7 +741,7 @@ public class Personalisation<E extends NotificationWrapper> {
     }
 
     public static int calculateMaxDwpResponseDays(String benefitCode) {
-        if (benefitCode == "childSupport") {
+        if (benefitCode.equals("childSupport")) {
             return MAX_DWP_RESPONSE_DAYS_CHILD_SUPPORT;
         } else {
             return MAX_DWP_RESPONSE_DAYS;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
@@ -85,8 +85,6 @@ public class Personalisation<E extends NotificationWrapper> {
     private static final String CRLF = format("%c%c", (char) 0x0D, (char) 0x0A);
     public static final String TEMPLATE_NAME_TEMPLATE_WITH_DIRECTION_TYPE = "%s.%s.%s";
     public static final String TEMPLATE_NAME_TEMPLATE = "%s.%s";
-    public static final int MAX_DWP_RESPONSE_DAYS = 28;
-    public static final int MAX_DWP_RESPONSE_DAYS_CHILD_SUPPORT = 42;
 
     @Autowired
     protected NotificationConfig config;
@@ -742,7 +740,7 @@ public class Personalisation<E extends NotificationWrapper> {
             subscriptionType.name().toLowerCase());
     }
 
-    private static int calculateMaxDwpResponseDays(String benefitCode) {
+    public static int calculateMaxDwpResponseDays(String benefitCode) {
         if (benefitCode == "childSupport" ) {
             return MAX_DWP_RESPONSE_DAYS_CHILD_SUPPORT;
         }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
@@ -490,7 +490,8 @@ public class Personalisation<E extends NotificationWrapper> {
 
     Map<String, Object> setEventData(Map<String, Object> personalisation, SscsCaseData ccdResponse, NotificationEventType notificationEventType) {
         if (ccdResponse.getCreatedInGapsFrom() != null && ccdResponse.getCreatedInGapsFrom().equals("readyToList")) {
-            LocalDate localDate = LocalDate.parse(ofNullable(ccdResponse.getDateSentToDwp()).orElse(LocalDate.now().toString())).plusDays(dwpResponseUtil.calculateMaxDwpResponseDays(ccdResponse.getBenefitCode()));
+            int dwpResponseDays = ofNullable(dwpResponseUtil.calculateMaxDwpResponseDays(ccdResponse.getBenefitCode())).orElse(dwpResponseUtil.MAX_DWP_RESPONSE_DAYS);
+            LocalDate localDate = LocalDate.parse(ofNullable(ccdResponse.getDateSentToDwp()).orElse(LocalDate.now().toString())).plusDays(dwpResponseDays);
             String dwpResponseDateString = formatLocalDate(localDate);
             personalisation.put(APPEAL_RESPOND_DATE, dwpResponseDateString);
             translateToWelshDate(localDate, ccdResponse, value ->
@@ -541,7 +542,8 @@ public class Personalisation<E extends NotificationWrapper> {
     }
 
     private Map<String, Object> setAppealReceivedDetails(Map<String, Object> personalisation, EventDetails eventDetails, SscsCaseData ccdResponse) {
-        LocalDate localDate = eventDetails.getDateTime().plusDays(dwpResponseUtil.calculateMaxDwpResponseDays(ccdResponse.getBenefitCode())).toLocalDate();
+        int dwpResponseDays = ofNullable(dwpResponseUtil.calculateMaxDwpResponseDays(ccdResponse.getBenefitCode())).orElse(dwpResponseUtil.MAX_DWP_RESPONSE_DAYS);
+        LocalDate localDate = eventDetails.getDateTime().plusDays(dwpResponseDays).toLocalDate();
         String dwpResponseDateString = formatLocalDate(localDate);
         personalisation.put(APPEAL_RESPOND_DATE, dwpResponseDateString);
         translateToWelshDate(localDate, ccdResponse, value ->

--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
@@ -77,6 +77,7 @@ import uk.gov.hmcts.reform.sscs.service.MessageAuthenticationServiceImpl;
 import uk.gov.hmcts.reform.sscs.service.RegionalProcessingCenterService;
 import uk.gov.hmcts.reform.sscs.service.SendNotificationHelper;
 import uk.gov.hmcts.reform.sscs.service.conversion.LocalDateToWelshStringConverter;
+import uk.gov.hmcts.reform.sscs.utility.dwpResponseUtil;
 
 @Component
 @Slf4j
@@ -168,7 +169,6 @@ public class Personalisation<E extends NotificationWrapper> {
             placeholders.accept(translatedDate);
         }
     }
-
 
     public Map<String, Object> create(final E notificationWrapper, final SubscriptionWithType subscriptionWithType) {
         return create(notificationWrapper.getSscsCaseDataWrapper(), subscriptionWithType);
@@ -490,7 +490,7 @@ public class Personalisation<E extends NotificationWrapper> {
 
     Map<String, Object> setEventData(Map<String, Object> personalisation, SscsCaseData ccdResponse, NotificationEventType notificationEventType) {
         if (ccdResponse.getCreatedInGapsFrom() != null && ccdResponse.getCreatedInGapsFrom().equals("readyToList")) {
-            LocalDate localDate = LocalDate.parse(ofNullable(ccdResponse.getDateSentToDwp()).orElse(LocalDate.now().toString())).plusDays(MAX_DWP_RESPONSE_DAYS);
+            LocalDate localDate = LocalDate.parse(ofNullable(ccdResponse.getDateSentToDwp()).orElse(LocalDate.now().toString())).plusDays(dwpResponseUtil.calculateMaxDwpResponseDays(ccdResponse.getBenefitCode()));
             String dwpResponseDateString = formatLocalDate(localDate);
             personalisation.put(APPEAL_RESPOND_DATE, dwpResponseDateString);
             translateToWelshDate(localDate, ccdResponse, value ->
@@ -506,7 +506,7 @@ public class Personalisation<E extends NotificationWrapper> {
                     || notificationEventType.equals(CASE_UPDATED)
                     || JUDGE_DECISION_APPEAL_TO_PROCEED.equals(notificationEventType)
                     || TCW_DECISION_APPEAL_TO_PROCEED.equals(notificationEventType)) {
-                    return setAppealReceivedDetails(personalisation, event.getValue(), ccdResponse);
+                    return setSentToDWPDetails(personalisation, event.getValue(), ccdResponse);
                 }
             }
         }
@@ -540,8 +540,8 @@ public class Personalisation<E extends NotificationWrapper> {
 
     }
 
-    private Map<String, Object> setAppealReceivedDetails(Map<String, Object> personalisation, EventDetails eventDetails, SscsCaseData ccdResponse) {
-        LocalDate localDate = eventDetails.getDateTime().plusDays(MAX_DWP_RESPONSE_DAYS).toLocalDate();
+    private Map<String, Object> setSentToDWPDetails(Map<String, Object> personalisation, EventDetails eventDetails, SscsCaseData ccdResponse) {
+        LocalDate localDate = eventDetails.getDateTime().plusDays(dwpResponseUtil.calculateMaxDwpResponseDays(ccdResponse.getBenefitCode())).toLocalDate();
         String dwpResponseDateString = formatLocalDate(localDate);
         personalisation.put(APPEAL_RESPOND_DATE, dwpResponseDateString);
         translateToWelshDate(localDate, ccdResponse, value ->

--- a/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/personalisation/Personalisation.java
@@ -506,7 +506,7 @@ public class Personalisation<E extends NotificationWrapper> {
                     || notificationEventType.equals(CASE_UPDATED)
                     || JUDGE_DECISION_APPEAL_TO_PROCEED.equals(notificationEventType)
                     || TCW_DECISION_APPEAL_TO_PROCEED.equals(notificationEventType)) {
-                    return setSentToDwpDetails(personalisation, event.getValue(), ccdResponse);
+                    return setAppealReceivedDetails(personalisation, event.getValue(), ccdResponse);
                 }
             }
         }
@@ -540,7 +540,7 @@ public class Personalisation<E extends NotificationWrapper> {
 
     }
 
-    private Map<String, Object> setSentToDwpDetails(Map<String, Object> personalisation, EventDetails eventDetails, SscsCaseData ccdResponse) {
+    private Map<String, Object> setAppealReceivedDetails(Map<String, Object> personalisation, EventDetails eventDetails, SscsCaseData ccdResponse) {
         LocalDate localDate = eventDetails.getDateTime().plusDays(dwpResponseUtil.calculateMaxDwpResponseDays(ccdResponse.getBenefitCode())).toLocalDate();
         String dwpResponseDateString = formatLocalDate(localDate);
         personalisation.put(APPEAL_RESPOND_DATE, dwpResponseDateString);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
@@ -30,6 +30,7 @@ import static uk.gov.hmcts.reform.sscs.config.SubscriptionType.JOINT_PARTY;
 import static uk.gov.hmcts.reform.sscs.config.SubscriptionType.OTHER_PARTY;
 import static uk.gov.hmcts.reform.sscs.config.SubscriptionType.REPRESENTATIVE;
 import static uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType.*;
+import static uk.gov.hmcts.reform.sscs.utility.dwpResponseUtil.calculateMaxDwpResponseDays;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -76,7 +77,6 @@ import uk.gov.hmcts.reform.sscs.reference.data.model.HearingChannel;
 import uk.gov.hmcts.reform.sscs.service.MessageAuthenticationServiceImpl;
 import uk.gov.hmcts.reform.sscs.service.RegionalProcessingCenterService;
 import uk.gov.hmcts.reform.sscs.service.conversion.LocalDateToWelshStringConverter;
-import uk.gov.hmcts.reform.sscs.utility.dwpResponseUtil;
 
 @Slf4j
 @RunWith(JUnitParamsRunner.class)
@@ -941,7 +941,7 @@ public class PersonalisationTest {
 
         Map result = personalisation.setEventData(new HashMap<>(), response, APPEAL_RECEIVED);
 
-        assertEquals(LocalDate.now().plusDays(dwpResponseUtil.calculateMaxDwpResponseDays(response.getBenefitCode())).format(DateTimeFormatter.ofPattern(RESPONSE_DATE_FORMAT)), result.get(APPEAL_RESPOND_DATE));
+        assertEquals(LocalDate.now().plusDays(calculateMaxDwpResponseDays(response.getBenefitCode())).format(DateTimeFormatter.ofPattern(RESPONSE_DATE_FORMAT)), result.get(APPEAL_RESPOND_DATE));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
@@ -883,6 +883,22 @@ public class PersonalisationTest {
         assertEquals("29 July 2018", result.get(APPEAL_RESPOND_DATE));
     }
 
+    @Test
+    public void setAppealReceivedChildSupportEventData() {
+        List<Event> events = new ArrayList<>();
+        events.add(Event.builder().value(EventDetails.builder().date(DATE).type(EventType.APPEAL_RECEIVED.getCcdType()).build()).build());
+
+        SscsCaseData response = SscsCaseData.builder()
+                .ccdCaseId(CASE_ID).caseReference("SC/1234/5")
+                .appeal(Appeal.builder().benefitType(BenefitType.builder().code("childSupport").build()).build())
+                .events(events)
+                .build();
+
+        Map result = personalisation.setEventData(new HashMap<>(), response, APPEAL_RECEIVED);
+
+        assertNull("Welsh date is not set ",  result.get(APPEAL_RESPOND_DATE_WELSH));
+        assertEquals("12 August 2018", result.get(APPEAL_RESPOND_DATE));
+    }
 
     @Test
     public void setAppealReceivedEventData_Welsh() {
@@ -899,6 +915,23 @@ public class PersonalisationTest {
         Map result = personalisation.setEventData(new HashMap<>(), response, APPEAL_RECEIVED);
         assertEquals("Welsh date is set ", getWelshDate().apply(result.get(APPEAL_RESPOND_DATE), dateTimeFormatter), result.get(APPEAL_RESPOND_DATE_WELSH));
         assertEquals("29 July 2018", result.get(APPEAL_RESPOND_DATE));
+    }
+
+    @Test
+    public void setAppealReceivedChildSupportEventData_Welsh() {
+        List<Event> events = new ArrayList<>();
+        events.add(Event.builder().value(EventDetails.builder().date(DATE).type(EventType.APPEAL_RECEIVED.getCcdType()).build()).build());
+
+        SscsCaseData response = SscsCaseData.builder()
+                .ccdCaseId(CASE_ID).caseReference("SC/1234/5")
+                .appeal(Appeal.builder().benefitType(BenefitType.builder().code("childSupport").build()).build())
+                .events(events)
+                .languagePreferenceWelsh("yes")
+                .build();
+
+        Map result = personalisation.setEventData(new HashMap<>(), response, APPEAL_RECEIVED);
+        assertEquals("Welsh date is set ", getWelshDate().apply(result.get(APPEAL_RESPOND_DATE), dateTimeFormatter), result.get(APPEAL_RESPOND_DATE_WELSH));
+        assertEquals("12 August 2018", result.get(APPEAL_RESPOND_DATE));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
@@ -941,7 +941,7 @@ public class PersonalisationTest {
 
         Map result = personalisation.setEventData(new HashMap<>(), response, APPEAL_RECEIVED);
 
-        assertEquals(LocalDate.now().plusDays(dwpResponseUtil.MAX_DWP_RESPONSE_DAYS).format(DateTimeFormatter.ofPattern(RESPONSE_DATE_FORMAT)), result.get(APPEAL_RESPOND_DATE));
+        assertEquals(LocalDate.now().plusDays(dwpResponseUtil.calculateMaxDwpResponseDays(response.getBenefitCode())).format(DateTimeFormatter.ofPattern(RESPONSE_DATE_FORMAT)), result.get(APPEAL_RESPOND_DATE));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
@@ -76,6 +76,7 @@ import uk.gov.hmcts.reform.sscs.reference.data.model.HearingChannel;
 import uk.gov.hmcts.reform.sscs.service.MessageAuthenticationServiceImpl;
 import uk.gov.hmcts.reform.sscs.service.RegionalProcessingCenterService;
 import uk.gov.hmcts.reform.sscs.service.conversion.LocalDateToWelshStringConverter;
+import uk.gov.hmcts.reform.sscs.utility.dwpResponseUtil;
 
 @Slf4j
 @RunWith(JUnitParamsRunner.class)
@@ -542,7 +543,7 @@ public class PersonalisationTest {
         assertEquals(benefitType.equals("taxCredit") ? "" : THE_STRING, result.get(WITH_OPTIONAL_THE));
         assertEquals(benefitType.equals("taxCredit") ? "" : THE_STRING_WELSH, result.get(WITH_OPTIONAL_THE_WELSH));
 
-        assertEquals("5 August 2018", result.get(APPEAL_RESPOND_DATE));
+        assertEquals("29 July 2018", result.get(APPEAL_RESPOND_DATE));
         assertEquals("http://link.com/GLSCRR", result.get(SUBMIT_EVIDENCE_LINK_LITERAL));
         assertEquals("http://link.com/progress/GLSCRR/expenses", result.get(CLAIMING_EXPENSES_LINK_LITERAL));
         assertEquals("http://link.com/progress/GLSCRR/abouthearing", result.get(HEARING_INFO_LINK_LITERAL));
@@ -613,7 +614,7 @@ public class PersonalisationTest {
         assertEquals(FormType.SSCS5.equals(formType) ? "" : THE_STRING, result.get(WITH_OPTIONAL_THE));
         assertEquals(FormType.SSCS5.equals(formType) ? "" : THE_STRING_WELSH, result.get(WITH_OPTIONAL_THE_WELSH));
 
-        assertEquals("5 August 2018", result.get(APPEAL_RESPOND_DATE));
+        assertEquals("29 July 2018", result.get(APPEAL_RESPOND_DATE));
         assertEquals("http://link.com/GLSCRR", result.get(SUBMIT_EVIDENCE_LINK_LITERAL));
         assertEquals("http://link.com/progress/GLSCRR/expenses", result.get(CLAIMING_EXPENSES_LINK_LITERAL));
         assertEquals("http://link.com/progress/GLSCRR/abouthearing", result.get(HEARING_INFO_LINK_LITERAL));
@@ -879,7 +880,7 @@ public class PersonalisationTest {
         Map result = personalisation.setEventData(new HashMap<>(), response, APPEAL_RECEIVED);
 
         assertNull("Welsh date is not set ",  result.get(APPEAL_RESPOND_DATE_WELSH));
-        assertEquals("5 August 2018", result.get(APPEAL_RESPOND_DATE));
+        assertEquals("29 July 2018", result.get(APPEAL_RESPOND_DATE));
     }
 
 
@@ -897,7 +898,7 @@ public class PersonalisationTest {
 
         Map result = personalisation.setEventData(new HashMap<>(), response, APPEAL_RECEIVED);
         assertEquals("Welsh date is set ", getWelshDate().apply(result.get(APPEAL_RESPOND_DATE), dateTimeFormatter), result.get(APPEAL_RESPOND_DATE_WELSH));
-        assertEquals("5 August 2018", result.get(APPEAL_RESPOND_DATE));
+        assertEquals("29 July 2018", result.get(APPEAL_RESPOND_DATE));
     }
 
     @Test
@@ -911,7 +912,7 @@ public class PersonalisationTest {
 
         Map<String, String> result = personalisation.setEventData(new HashMap<>(), response, APPEAL_RECEIVED);
         assertNull("Welsh date is set ", result.get(APPEAL_RESPOND_DATE_WELSH));
-        assertEquals("5 August 2018", result.get(APPEAL_RESPOND_DATE));
+        assertEquals("29 July 2018", result.get(APPEAL_RESPOND_DATE));
     }
 
     @Test
@@ -927,7 +928,7 @@ public class PersonalisationTest {
         Map<String, String> result = personalisation.setEventData(new HashMap<>(), response, APPEAL_RECEIVED);
 
         assertEquals("Welsh date is set ", getWelshDate().apply(result.get(APPEAL_RESPOND_DATE), dateTimeFormatter), result.get(APPEAL_RESPOND_DATE_WELSH));
-        assertEquals("5 August 2018", result.get(APPEAL_RESPOND_DATE));
+        assertEquals("29 July 2018", result.get(APPEAL_RESPOND_DATE));
     }
 
     @Test
@@ -940,7 +941,7 @@ public class PersonalisationTest {
 
         Map result = personalisation.setEventData(new HashMap<>(), response, APPEAL_RECEIVED);
 
-        assertEquals(LocalDate.now().plusDays(MAX_DWP_RESPONSE_DAYS).format(DateTimeFormatter.ofPattern(RESPONSE_DATE_FORMAT)), result.get(APPEAL_RESPOND_DATE));
+        assertEquals(LocalDate.now().plusDays(dwpResponseUtil.MAX_DWP_RESPONSE_DAYS).format(DateTimeFormatter.ofPattern(RESPONSE_DATE_FORMAT)), result.get(APPEAL_RESPOND_DATE));
     }
 
     @Test
@@ -992,7 +993,7 @@ public class PersonalisationTest {
 
         Map result = personalisation.setEventData(new HashMap<>(), response, JUDGE_DECISION_APPEAL_TO_PROCEED);
 
-        assertEquals("5 August 2018", result.get(APPEAL_RESPOND_DATE));
+        assertEquals("29 July 2018", result.get(APPEAL_RESPOND_DATE));
     }
 
     @Test
@@ -1008,7 +1009,7 @@ public class PersonalisationTest {
 
         Map result = personalisation.setEventData(new HashMap<>(), response, TCW_DECISION_APPEAL_TO_PROCEED);
 
-        assertEquals("5 August 2018", result.get(APPEAL_RESPOND_DATE));
+        assertEquals("29 July 2018", result.get(APPEAL_RESPOND_DATE));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
@@ -30,7 +30,6 @@ import static uk.gov.hmcts.reform.sscs.config.SubscriptionType.JOINT_PARTY;
 import static uk.gov.hmcts.reform.sscs.config.SubscriptionType.OTHER_PARTY;
 import static uk.gov.hmcts.reform.sscs.config.SubscriptionType.REPRESENTATIVE;
 import static uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType.*;
-import static uk.gov.hmcts.reform.sscs.personalisation.Personalisation.calculateMaxDwpResponseDays;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -974,7 +973,7 @@ public class PersonalisationTest {
 
         Map result = personalisation.setEventData(new HashMap<>(), response, APPEAL_RECEIVED);
 
-        assertEquals(LocalDate.now().plusDays(calculateMaxDwpResponseDays(response.getBenefitCode())).format(DateTimeFormatter.ofPattern(RESPONSE_DATE_FORMAT)), result.get(APPEAL_RESPOND_DATE));
+        assertEquals(LocalDate.now().plusDays(personalisation.calculateMaxDwpResponseDays(response.getBenefitCode())).format(DateTimeFormatter.ofPattern(RESPONSE_DATE_FORMAT)), result.get(APPEAL_RESPOND_DATE));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/personalisation/PersonalisationTest.java
@@ -30,7 +30,7 @@ import static uk.gov.hmcts.reform.sscs.config.SubscriptionType.JOINT_PARTY;
 import static uk.gov.hmcts.reform.sscs.config.SubscriptionType.OTHER_PARTY;
 import static uk.gov.hmcts.reform.sscs.config.SubscriptionType.REPRESENTATIVE;
 import static uk.gov.hmcts.reform.sscs.domain.notify.NotificationEventType.*;
-import static uk.gov.hmcts.reform.sscs.utility.dwpResponseUtil.calculateMaxDwpResponseDays;
+import static uk.gov.hmcts.reform.sscs.personalisation.Personalisation.calculateMaxDwpResponseDays;
 
 import java.time.Instant;
 import java.time.LocalDate;


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/SSCSCI-830


### Change description ###
Notifications messages dwp due date should be set as: 
- Child Support cases should be calculated as 'Sent to FTA' event's date plus 42 days
- All other case types as plus 28 days
