### PR TITLE
Upgrade snakeyaml to 2.0 - CVE-2022-1471

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,10 +201,8 @@ dependencyManagement {
             entry 'spring-cloud-openfeign-core'
         }
 
-        //CVE-2022-25857
-        dependencySet(group: 'org.yaml', version: '1.33') {
-            entry 'snakeyaml'
-        }
+        //CVE-2022-1471
+        dependency group: 'org.yaml', name: 'snakeyaml', version: '2.0'
 
         //CVE-2021-42550
         dependencySet(group: 'ch.qos.logback', version: '1.2.11') {

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until = "2024-05-01">
+    <suppress until = "2024-06-01">
         <cve>CVE-2022-42004</cve>
         <cve>CVE-2023-39017</cve>
         <cve>CVE-2022-42003</cve>
         <cve>CVE-2023-5072</cve>
         <cve>CVE-2023-34462</cve>
-        <cve>CVE-2022-1471</cve>
         <cve>CVE-2023-34055</cve>
         <cve>CVE-2023-44487</cve>
         <cve>CVE-2023-20883</cve>
@@ -15,7 +14,6 @@
         <cve>CVE-2023-35116</cve>
         <cve>CVE-2021-46877</cve>
         <cve>CVE-2023-6378</cve>
-        <cve>CVE-2024-1597</cve>
         <cve>CVE-2023-1370</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/SSCSCI-845

### Change description ###

Updated snakeyaml from 1.33 to 2.0 to fix CVE-2022-1471
Removed CVE-2024-1597 from suppressions as postgresql is already upgraded to latest available version (42.7.3)