### PR TITLE
SSCSSI-331 | Add initial delays and maxdelay for async corresponding processing

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/config/LetterAsyncConfigProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/config/LetterAsyncConfigProperties.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.sscs.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "letter-async")
+@Getter
+@Setter
+public class LetterAsyncConfigProperties {
+    private int maxAttempts;
+    private long delay;
+    private double multiplier;
+    private long maxDelay;
+    private long initialDelay;
+
+    // getters and setters
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/config/LetterAsyncConfigProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/config/LetterAsyncConfigProperties.java
@@ -15,6 +15,4 @@ public class LetterAsyncConfigProperties {
     private double multiplier;
     private long maxDelay;
     private long initialDelay;
-
-    // getters and setters
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/SaveCorrespondenceAsyncService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/SaveCorrespondenceAsyncService.java
@@ -13,6 +13,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Correspondence;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.config.LetterAsyncConfigProperties;
 import uk.gov.hmcts.reform.sscs.config.SubscriptionType;
 import uk.gov.hmcts.reform.sscs.model.LetterType;
 import uk.gov.service.notify.NotificationClient;
@@ -28,20 +29,19 @@ public class SaveCorrespondenceAsyncService {
         this.ccdNotificationsPdfService = ccdNotificationsPdfService;
     }
 
-    @Value("${letterAsync.initialDelay}")
-    private long initialDelay;
+    @Autowired
+    private LetterAsyncConfigProperties letterAsyncConfigProperties;
 
     @Async
-    @Retryable(maxAttemptsExpression = "#{environment['letterAsync.maxAttempts']}", backoff = @Backoff(delayExpression = "#{environment['letterAsync.delay']}", multiplierExpression = "#{environment['letterAsync.multiplier']}",
-        random = true, maxDelayExpression = "#{environment['letterAsync.maxDelay']}"))
+    @Retryable(maxAttemptsExpression = "#{@letterAsyncConfigProperties.maxAttempts}", backoff = @Backoff(delayExpression = "#{@letterAsyncConfigProperties.delay}", multiplierExpression = "#{@letterAsyncConfigProperties.multiplier}", random = true, maxDelayExpression = "#{@letterAsyncConfigProperties.maxDelay}"))
     public void saveLetter(NotificationClient client, String notificationId, Correspondence correspondence, String ccdCaseId) throws NotificationClientException {
 
         RetryContext context = RetrySynchronizationManager.getContext();
         if (context != null && context.getRetryCount() == 0) {
-            log.debug("delaying by {} milliseconds before making first attempt to get letter pdf for case id : {}",initialDelay, ccdCaseId);
+            log.debug("delaying by {} milliseconds before making first attempt to get letter pdf for case id : {}",letterAsyncConfigProperties.getInitialDelay(), ccdCaseId);
             try {
                 // Using  Thread.sleep here as it's already running in async and not blocking end user requests. Using CompletableFuture is too complex for this.
-                Thread.sleep(initialDelay);
+                Thread.sleep(letterAsyncConfigProperties.getInitialDelay());
             } catch (InterruptedException e) {
                 log.warn("Thread was interrupted while applying a sleep to get letter pdf for case id : {} ", ccdCaseId);
                 Thread.currentThread().interrupt();
@@ -62,13 +62,7 @@ public class SaveCorrespondenceAsyncService {
     }
 
     @Async
-    @Retryable(maxAttemptsExpression = "#{${letterAsync.maxAttempts}}", backoff = @Backoff(delayExpression = "#{${letterAsync.delay}}", multiplierExpression = "#{${letterAsync.multiplier}}", random = true))
-    public void saveLetter(Correspondence correspondence, final byte[] pdfForLetter, String ccdCaseId) {
-        ccdNotificationsPdfService.mergeLetterCorrespondenceIntoCcd(pdfForLetter, Long.valueOf(ccdCaseId), correspondence);
-    }
-
-    @Async
-    @Retryable(maxAttemptsExpression = "#{${letterAsync.maxAttempts}}", backoff = @Backoff(delayExpression = "#{${letterAsync.delay}}", multiplierExpression = "#{${letterAsync.multiplier}}", random = true))
+    @Retryable(maxAttemptsExpression = "#{@letterAsyncConfigProperties.maxAttempts}", backoff = @Backoff(delayExpression = "#{@letterAsyncConfigProperties.delay}", multiplierExpression = "#{@letterAsyncConfigProperties.multiplier}", random = true))
     public void saveLetter(final byte[] pdfForLetter, Correspondence correspondence, String ccdCaseId, SubscriptionType subscriptionType) {
         log.info("Using notification letter correspondence V2 to upload reasonable adjustments correspondence for {} ", ccdCaseId);
         ccdNotificationsPdfService.mergeReasonableAdjustmentsCorrespondenceIntoCcdV2(pdfForLetter, Long.valueOf(ccdCaseId), correspondence, LetterType.findLetterTypeFromSubscription(subscriptionType.name()));

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/SaveCorrespondenceAsyncService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/SaveCorrespondenceAsyncService.java
@@ -32,7 +32,8 @@ public class SaveCorrespondenceAsyncService {
     private long initialDelay;
 
     @Async
-    @Retryable(maxAttemptsExpression = "#{${letterAsync.maxAttempts}}", backoff = @Backoff(delayExpression = "#{${letterAsync.delay}}", multiplierExpression = "#{${letterAsync.multiplier}}", random = true, maxDelayExpression = "#{${letterAsync.maxDelay}}"))
+    @Retryable(maxAttemptsExpression = "#{environment['letterAsync.maxAttempts']}", backoff = @Backoff(delayExpression = "#{environment['letterAsync.delay']}", multiplierExpression = "#{environment['letterAsync.multiplier']}",
+        random = true, maxDelayExpression = "#{environment['letterAsync.maxDelay']}"))
     public void saveLetter(NotificationClient client, String notificationId, Correspondence correspondence, String ccdCaseId) throws NotificationClientException {
 
         RetryContext context = RetrySynchronizationManager.getContext();

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/SaveCorrespondenceAsyncService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/SaveCorrespondenceAsyncService.java
@@ -43,7 +43,8 @@ public class SaveCorrespondenceAsyncService {
                 // Using  Thread.sleep here as it's already running in async and not blocking end user requests. Using CompletableFuture is too complex for this.
                 Thread.sleep(initialDelay);
             } catch (InterruptedException e) {
-                throw new RuntimeException(e);
+                log.warn("Thread was interrupted while applying a sleep to get letter pdf for case id : {} ", ccdCaseId);
+                Thread.currentThread().interrupt();
             }
         }
         try {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/SaveCorrespondenceAsyncService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/SaveCorrespondenceAsyncService.java
@@ -1,9 +1,7 @@
 package uk.gov.hmcts.reform.sscs.service;
 
-import java.util.concurrent.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1447,7 +1447,7 @@ feature.postHearings.enabled: ${POST_HEARINGS_FEATURE:false}
 feature.postHearingsB.enabled: ${POST_HEARINGS_B_FEATURE:false}
 feature.elinksV2.enabled: false
 
-letterAsync:
+letter-async:
   maxAttempts: ${LETTER_ASYNC_MAX_ATTEMPTS:10}
   delay: ${LETTER_ASYNC_DELAY:10000}
   multiplier: ${LETTER_ASYNC_MULTIPLIER:2}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1448,9 +1448,11 @@ feature.postHearingsB.enabled: ${POST_HEARINGS_B_FEATURE:false}
 feature.elinksV2.enabled: false
 
 letterAsync:
-  maxAttempts: ${LETTER_ASYNC_MAX_ATTEMPTS:5}
-  delay: ${LETTER_ASYNC_DELAY:6000}
-  multiplier: ${LETTER_ASYNC_MULTIPLIER:10}
+  maxAttempts: ${LETTER_ASYNC_MAX_ATTEMPTS:10}
+  delay: ${LETTER_ASYNC_DELAY:10000}
+  multiplier: ${LETTER_ASYNC_MULTIPLIER:2}
+  maxDelay: ${LETTER_ASYNC_MAX_DELAY:180000}
+  initialDelay: ${LETTER_ASYNC_INITIAL_DELAY:5000}
 
 retry:
   max: 3


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/SSCSSI-331 

### Change description ###

- Setting maxDelay as the default is 30 seconds if unspecified thus limiting the overall time for retries to just under 2 minutes.
- Nearly 7%  of the PDFs are not ready by then, tuning maxRetries, delays and multiplier to wait for a maximum of15 minutes.
- Also adding initialDelay for first attempt with Thread.sleep as first attempt is always failing. 

- Alternative approach to handle Thread.Sleep will be something like, but we cannot avoid the Thread from waiting to continue further.

```Java
  if(context != null && context.getRetryCount() == 0){
        log.info("adding additional wait");
        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
        try {
        CompletableFuture<Void> delayedFuture = CompletableFuture.runAsync(() -> {}, CompletableFuture.delayedExecutor(initialDelay, TimeUnit.MILLISECONDS, executor));
        delayedFuture.join();
        } finally {
            executor.shutdown();
        }
    }
```

- or a more complex approach like below as exception handling is key for Retryable to work as expected.

 ```Java
ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();

        try {

            // Use CompletableFuture to introduce a delay before throwing the exception
            CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {}, executor)
                .thenRunAsync(() -> {
                    try {
                        final byte[] pdfForLetter = client.getPdfForLetter(notificationId);
                        log.info("Using merge letter correspondence V2 to upload letter correspondence for {} ", ccdCaseId);
                        ccdNotificationsPdfService.mergeLetterCorrespondenceIntoCcdV2(pdfForLetter, Long.valueOf(ccdCaseId), correspondence);
                    } catch (NotificationClientException e) {
                        throw new CompletionException(e);
                    }
                }, CompletableFuture.delayedExecutor(5, TimeUnit.SECONDS, executor));

            // Wait for the future to complete to catch the exception
            future.join();
        } catch (CompletionException e) {
            Throwable cause = e.getCause();
            if (cause instanceof NotificationClientException) {
                NotificationClientException nce = (NotificationClientException) cause;
                if (nce.getMessage().contains("PDFNotReadyError")) {
                    log.info("Got a PDFNotReadyError back from gov.notify for case id: {}.", ccdCaseId);
                } else {
                    log.warn("Got a strange error '{}' back from gov.notify for case id: {}.", nce.getMessage(), ccdCaseId);
                }
            } else {
                log.error("An error occurred", e);
            }
            throw e;
        } finally {
            // Shutdown the executor
            executor.shutdown();
        }
    }
```

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
