### PR TITLE
Update Docmosis HealthCheck for v2.9.7

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/health/DocmosisHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/health/DocmosisHealthIndicator.java
@@ -42,11 +42,14 @@ public class DocmosisHealthIndicator implements HealthIndicator {
                         }
                     ).getBody();
 
-            if (response != null
-                && response.containsKey("ready")
-                && "true".equalsIgnoreCase((String) response.get("ready"))) {
-
-                return new Health.Builder().up().build();
+            if (response != null && response.containsKey("ready")) {
+                Object readyValue = response.get("ready");
+                if ((readyValue instanceof String && "true".equalsIgnoreCase((String) readyValue))
+                        || (readyValue instanceof Boolean && Boolean.TRUE.equals(readyValue))) {
+                    return new Health.Builder().up().build();
+                } else {
+                    return new Health.Builder().down().build();
+                }
             } else {
                 return new Health.Builder().down().build();
             }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/health/DocmosisHealthIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/health/DocmosisHealthIndicatorTest.java
@@ -53,7 +53,7 @@ public class DocmosisHealthIndicatorTest {
         Map<String, Object> exampleReadyResponse =
             ImmutableMap
                 .of(
-                    "ready", "true"
+                    "ready", true
                 );
 
         when(responseEntity.getBody()).thenReturn(exampleReadyResponse);
@@ -67,7 +67,7 @@ public class DocmosisHealthIndicatorTest {
         Map<String, Object> exampleNotReadyResponse =
             ImmutableMap
                 .of(
-                    "ready", "false"
+                    "ready", false
                 );
 
         when(responseEntity.getBody()).thenReturn(exampleNotReadyResponse);


### PR DESCRIPTION
Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-18047

Change description

New Docmosis version introduces changes to the /status endpoint which is used for healthchecks. The value of "ready" has changed from a String to a Boolean value
Updates DocmosisHealthIndicator.java to check for Boolean true OR String "true" so it is backward compatible. Check for String can be removed once Docmosis has been upgraded.
Updates DocmosisHealthIndicatorTest.java to include Boolean values instead of String as this is the new format
