### PR TITLE
Remove Jenkins logs being shipped to appinsights

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -31,7 +31,6 @@ def secrets = [
     secret('docmosis-endpoint', 'PDF_SERVICE_BASE_URL'),
     secret('docmosis-api-key', 'PDF_SERVICE_ACCESS_KEY'),
     secret('evidence-share-topic-shared-access-key', 'AMQP_PASSWORD'),
-    secret('AppInsightsInstrumentationKey', 'APPINSIGHTS_INSTRUMENTATIONKEY'),
 
     // Used by Kubernetes
     secret('idam-s2s-api', 'IDAM_S2S_AUTH'),

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -39,7 +39,6 @@ def secrets = [
         secret('docmosis-endpoint', 'PDF_SERVICE_BASE_URL'),
         secret('docmosis-api-key', 'PDF_SERVICE_ACCESS_KEY'),
         secret('evidence-share-topic-shared-access-key', 'AMQP_PASSWORD'),
-        secret('AppInsightsInstrumentationKey', 'APPINSIGHTS_INSTRUMENTATIONKEY'),
 
         // Used by Kubernetes
         secret('idam-s2s-api', 'IDAM_S2S_AUTH'),


### PR DESCRIPTION
### Jira link

Currently Jenkins logs contributes the most logs as all functional test and possibly unit/integration test logs are being shipped every time a build is run.

App should still get the key from  https://github.com/hmcts/sscs-track-your-appeal-notifications/blob/master/charts/sscs-tya-notif/values.yaml#L46


### Testing done


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
